### PR TITLE
jw.change_output_dir

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -162,9 +162,15 @@ android {
         }
     }
 
+    // Change output dir of artifacts to live under builds subdir of /app
     android.applicationVariants.all { variant ->
+        def newDir = variant.baseName.replace("-", "/")
         variant.outputs.all {
-            outputFileName = "GoIV-${variant.name}.${variant.versionName}.apk"
+            def name = variant.baseName
+            if (!variant.baseName.startsWith("playstore")) {
+                name = name.replace("-release", "")
+            }
+            outputFileName = "../../builds/${newDir}/GoIV-${name}.${variant.versionName}.apk"
         }
     }
 }
@@ -205,7 +211,6 @@ dependencies {
     implementation project(':openCVLibrary330')
 
     /* for devMethods.thirdparty.pokebattler, temporally set for All Builds */
-//    implementation 'org.json:json:20160810' //used to generate moveset list
     implementation 'com.squareup.okhttp3:okhttp:3.7.0'//used to generate moveset list
 
     /**


### PR DESCRIPTION
Remove deprecated dependency.
Change output directory for APKs.

>other minor niceties, would be getting the release builds to properly go in app/builds instead of directly into app/, and if you could get the offlineRelease and onlineRelease builds to output their files without "Release" in the name, it would effectively automate one of the steps in actually uploading and publishing the APKs, so that would be rad

This what you wanted?

```bash
$ tree app/builds
app/builds
├── offline
│   ├── debug
│   │   └── GoIV-offline-debug.5.5.1-beta.apk
│   └── release
│       └── GoIV-offline.5.5.1-beta.apk
├── online
│   ├── debug
│   │   └── GoIV-online-debug.5.5.1-beta.apk
│   └── release
│       └── GoIV-online.5.5.1-beta.apk
└── playstore
    ├── debug
    │   └── GoIV-playstore-debug.5.5.1-beta.apk
    └── release
        └── GoIV-playstore.5.5.1-beta.apk
```