### PR TITLE
Bump to v5.5.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,8 @@ android {
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 29 /*Dont change this unless you know why*/
-        versionCode 71
-        versionName "5.5.4"
+        versionCode 72
+        versionName "5.5.5"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,8 +82,8 @@ android {
     defaultConfig {
         minSdkVersion 19 /*Dont change this unless you know why*/
         targetSdkVersion 29 /*Dont change this unless you know why*/
-        versionCode 72
-        versionName "5.5.5"
+        versionCode 73
+        versionName "5.5.6"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         vectorDrawables.useSupportLibrary = true
     }

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokeInfoCalculator.java
@@ -27,13 +27,13 @@ public class PokeInfoCalculator {
     private List<Pokemon> formVariantPokemons;
     private String[] pokeNamesWithForm = {};
 
-    public static final int MELTAN_INDEX_OFFSET = 7;
-    public static final int MELMETAL_INDEX_OFFSET = 6;
-    public static final int OBSTAGOON_INDEX_OFFSET = 5;
-    public static final int PERRSERKER_INDEX_OFFSET = 4;
-    public static final int SIRFETCHD_INDEX_OFFSET = 3;
-    public static final int MRRIME_INDEX_OFFSET = 2;
-    public static final int RUNERIGUS_INDEX_OFFSET = 1;
+    //public static final int MELTAN_INDEX_OFFSET = 7;
+    //public static final int MELMETAL_INDEX_OFFSET = 6;
+    //public static final int OBSTAGOON_INDEX_OFFSET = 5;
+    //public static final int PERRSERKER_INDEX_OFFSET = 4;
+    //public static final int SIRFETCHD_INDEX_OFFSET = 3;
+    //public static final int MRRIME_INDEX_OFFSET = 2;
+    //public static final int RUNERIGUS_INDEX_OFFSET = 1;
 
     /**
      * Pokemons who's name appears as a type of candy.
@@ -185,21 +185,6 @@ public class PokeInfoCalculator {
         int pokeListSize = names.length;
         ArrayList<Pokemon> formVariantPokemons = new ArrayList<>();
 
-        // quick hardcoded patch for supporting discontinuous pokedex number pokemons followings
-        //   #808 Meltan
-        //   #809 Melmetal
-        //   #862 Obstagoon
-        //   #863 Perrserker
-        //   #865 Sirfetch'd
-        //   #866 Mr. Rime
-        //   #867 Runerigus
-        // currently GoIV logic expects that pokedex numbers are continuous and less than pokeListSize.
-        // so this patch shifts these to dummy indexes, with pokeListSize offset.
-        candyNamesArray[pokeListSize - MELTAN_INDEX_OFFSET] = pokeListSize - MELTAN_INDEX_OFFSET;
-        candyNamesArray[pokeListSize - MELMETAL_INDEX_OFFSET] = pokeListSize - MELTAN_INDEX_OFFSET;
-        devolution[pokeListSize - MELMETAL_INDEX_OFFSET] = pokeListSize - MELTAN_INDEX_OFFSET;
-        // END patch for supporting discontinuous pokedex number pokemons
-
         for (int i = 0; i < pokeListSize; i++) {
             PokemonBase p = new PokemonBase(names[i], displayNames[i], i, devolution[i],
                                             candyNamesArray[i], evolutionCandyCost[i]);
@@ -211,7 +196,10 @@ public class PokeInfoCalculator {
                 PokemonBase devo = pokedex.get(devolution[i]);
                 devo.evolutions.add(pokedex.get(i));
             } else {
-                candyPokemons.add(pokedex.get(candyNamesArray[i]));
+                int candyNameIndex = candyNamesArray[i];
+                if (candyNameIndex != -1) {
+                    candyPokemons.add(pokedex.get(candyNameIndex));
+                }
             }
 
             PokemonBase base = pokedex.get(i);

--- a/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
+++ b/app/src/main/java/com/kamron/pogoiv/scanlogic/PokemonBase.java
@@ -88,7 +88,7 @@ public class PokemonBase {
 
         final int pokeListSize = PokeInfoCalculator.getInstance().getPokedex().size();
 
-        if (number == 51) { // #52 Meowth
+/*        if (number == 51) { // #52 Meowth
             // check #863 Perrserker with its index number in pokemons.xml
             if (otherForm.number == pokeListSize - PokeInfoCalculator.PERRSERKER_INDEX_OFFSET) {
                 // return Galarian forms
@@ -176,7 +176,7 @@ public class PokemonBase {
             } else {
                 return getForm(otherForm.formName);
             }
-        }
+        } */
 
         if ((otherForm.base.forms.size() == 1 && forms.size() > 1)
                 || (forms.size() == 1 && otherForm.base.forms.size() > 1 && otherForm.base.forms.get(0) == otherForm)) {

--- a/app/src/main/res/values-de/pokemons.xml
+++ b/app/src/main/res/values-de/pokemons.xml
@@ -715,12 +715,99 @@
         <item>UHaFnir</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Diancie</item>
+        <item>Hoopa</item>
+        <item>Volcanion</item>
         <item>Meltan</item>
         <item>Melmetal</item>
+        <item>Chimpep</item>
+        <item>Chimstix</item>
+        <item>Gortrom</item>
+        <item>Hopplo</item>
+        <item>Kickerlo</item>
+        <item>Liberlo</item>
+        <item>Memmeon</item>
+        <item>Phlegleon</item>
+        <item>Intelleon</item>
+        <item>Raffel</item>
+        <item>Schlaraffel</item>
+        <item>Meikro</item>
+        <item>Kranoviz</item>
+        <item>Krarmor</item>
+        <item>Sensect</item>
+        <item>Keradar</item>
+        <item>Maritellit</item>
+        <item>Kleptifux</item>
+        <item>Gaunux</item>
+        <item>Cottini</item>
+        <item>Cottomi</item>
+        <item>Wolly</item>
+        <item>Zwollock</item>
+        <item>Kamehaps</item>
+        <item>Kamalm</item>
+        <item>Voldi</item>
+        <item>Bellektro</item>
+        <item>Klonkett</item>
+        <item>Wagong</item>
+        <item>Montecarbo</item>
+        <item>Knapfel</item>
+        <item>Drapfel</item>
+        <item>Schlapfel</item>
+        <item>Salanga</item>
+        <item>Sanaconda</item>
+        <item>Urgl</item>
+        <item>Pikuda</item>
+        <item>Barrakiefa</item>
+        <item>Toxel</item>
+        <item>Riffex</item>
+        <item>Thermopod</item>
+        <item>Infernopod</item>
+        <item>Klopptopus</item>
+        <item>Kaocto</item>
+        <item>Fatalitee</item>
+        <item>Mortipot</item>
+        <item>Brimova</item>
+        <item>Brimano</item>
+        <item>Silembrim</item>
+        <item>Bähmon</item>
+        <item>Pelzebub</item>
+        <item>Olangaar</item>
         <item>Barrikadax</item>
         <item>Mauzinger</item>
+        <item>Gorgasonn</item>
         <item>Lauchzelot</item>
         <item>Pantifrost</item>
         <item>Oghnatoll</item>
+        <item>Hokumil</item>
+        <item>Pokusan</item>
+        <item>Legios</item>
+        <item>Britzigel</item>
+        <item>Snomnom</item>
+        <item>Mottineva</item>
+        <item>Humanolith</item>
+        <item>Kubuin</item>
+        <item>Servol</item>
+        <item>Morpeko</item>
+        <item>Kupfanti</item>
+        <item>Patinaraja</item>
+        <item>Lectragon</item>
+        <item>Lecryodon</item>
+        <item>Pescragon</item>
+        <item>Pescryodon</item>
+        <item>Duraludon</item>
+        <item>Grolldra</item>
+        <item>Phandra</item>
+        <item>Katapuldra</item>
+        <item>Zacian</item>
+        <item>Zamazenta</item>
+        <item>Endynalos</item>
+        <item>Dakuma</item>
+        <item>Wulaosu</item>
+        <item>Zarude</item>
+        <item>Regieleki</item>
+        <item>Regidrago</item>
+        <item>Polaross</item>
+        <item>Phantoross</item>
+        <item>Coronospa</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-de/pokemons.xml
+++ b/app/src/main/res/values-de/pokemons.xml
@@ -679,6 +679,9 @@
         <item>Coiffwaff</item>
         <item>Psiau</item>
         <item>Psiaugon</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Parfi</item>
         <item>Parfinesse</item>
         <item>Flauschling</item>
@@ -715,9 +718,96 @@
         <item>UHaFnir</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Placeholder</item>
         <item>Diancie</item>
         <item>Hoopa</item>
         <item>Volcanion</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Meltan</item>
         <item>Melmetal</item>
         <item>Chimpep</item>

--- a/app/src/main/res/values-fr/pokemons.xml
+++ b/app/src/main/res/values-fr/pokemons.xml
@@ -679,6 +679,9 @@
         <item>Couafarel</item>
         <item>Psystigri</item>
         <item>Mistigrix</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Fluvetin</item>
         <item>Cocotine</item>
         <item>Sucroquin</item>
@@ -715,9 +718,96 @@
         <item>Bruyverne</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Placeholder</item>
         <item>Diancie</item>
         <item>Hoopa</item>
         <item>Volcanion</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Meltan</item>
         <item>Melmetal</item>
         <item>Ouistempo</item>

--- a/app/src/main/res/values-fr/pokemons.xml
+++ b/app/src/main/res/values-fr/pokemons.xml
@@ -715,12 +715,99 @@
         <item>Bruyverne</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Diancie</item>
+        <item>Hoopa</item>
+        <item>Volcanion</item>
         <item>Meltan</item>
         <item>Melmetal</item>
+        <item>Ouistempo</item>
+        <item>Badabouin</item>
+        <item>Gorythmic</item>
+        <item>Flambino</item>
+        <item>Lapyro</item>
+        <item>Pyrobut</item>
+        <item>Larméléon</item>
+        <item>Arrozard</item>
+        <item>Lézargus</item>
+        <item>Rongourmand</item>
+        <item>Rongrigou</item>
+        <item>Minisange</item>
+        <item>Bleuseille</item>
+        <item>Corvaillus</item>
+        <item>Larvadar</item>
+        <item>Coléodôme</item>
+        <item>Astronelle</item>
+        <item>Goupilou</item>
+        <item>Roublenard</item>
+        <item>Tournicoton</item>
+        <item>Blancoton</item>
+        <item>Moumouton</item>
+        <item>Moumouflon</item>
+        <item>Khélocrok</item>
+        <item>Torgamord</item>
+        <item>Voltoutou</item>
+        <item>Fulgudog</item>
+        <item>Charbi</item>
+        <item>Wagomine</item>
+        <item>Monthracite</item>
+        <item>Verpom</item>
+        <item>Pomdrapi</item>
+        <item>Dratatin</item>
+        <item>Dunaja</item>
+        <item>Dunaconda</item>
+        <item>Nigosier</item>
+        <item>Embrochet</item>
+        <item>Hastacuda</item>
+        <item>Toxizap</item>
+        <item>Salarsen</item>
+        <item>Grillepattes</item>
+        <item>Centiskorch</item>
+        <item>Poulpaf</item>
+        <item>Krakos</item>
+        <item>Théffroi</item>
+        <item>Polthégeist</item>
+        <item>Bibichut</item>
+        <item>Chapotus</item>
+        <item>Sorcilence</item>
+        <item>Grimalin</item>
+        <item>Fourbelin</item>
+        <item>Angoliath</item>
         <item>Ixon</item>
         <item>Berserkatt</item>
+        <item>Corayôme</item>
         <item>Palarticho</item>
         <item>M. Glaquette</item>
         <item>Tutétékri</item>
+        <item>Crèmy</item>
+        <item>Charmilly</item>
+        <item>Hexadron</item>
+        <item>Wattapik</item>
+        <item>Frissonille</item>
+        <item>Beldeneige</item>
+        <item>Dolman</item>
+        <item>Bekaglaçon</item>
+        <item>Wimessir</item>
+        <item>Morpeko</item>
+        <item>Charibari</item>
+        <item>Pachyradjah</item>
+        <item>Galvagon</item>
+        <item>Galvagla</item>
+        <item>Hydragon</item>
+        <item>Hydragla</item>
+        <item>Duralugon</item>
+        <item>Fantyrm</item>
+        <item>Dispareptil</item>
+        <item>Lanssorien</item>
+        <item>Zacian</item>
+        <item>Zamazenta</item>
+        <item>Éthernatos</item>
+        <item>Wushours</item>
+        <item>Shifours</item>
+        <item>Zarude</item>
+        <item>Regieleki</item>
+        <item>Regidrago</item>
+        <item>Blizzeval</item>
+        <item>Spectreval</item>
+        <item>Sylveroy</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ja/pokemons.xml
+++ b/app/src/main/res/values-ja/pokemons.xml
@@ -679,6 +679,9 @@
         <item>トリミアン</item>
         <item>ニャスパー</item>
         <item>ニャオニクス</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>シュシュプ</item>
         <item>フレフワン</item>
         <item>ペロッパフ</item>
@@ -715,9 +718,96 @@
         <item>オンバーン</item>
         <item>ゼルネアス</item>
         <item>イベルタル</item>
+        <item>Placeholder</item>
         <item>ディアンシー</item>
         <item>フーパ</item>
         <item>ボルケニオン</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>メルタン</item>
         <item>メルメタル</item>
         <item>サルノリ</item>

--- a/app/src/main/res/values-ja/pokemons.xml
+++ b/app/src/main/res/values-ja/pokemons.xml
@@ -715,12 +715,99 @@
         <item>オンバーン</item>
         <item>ゼルネアス</item>
         <item>イベルタル</item>
+        <item>ディアンシー</item>
+        <item>フーパ</item>
+        <item>ボルケニオン</item>
         <item>メルタン</item>
         <item>メルメタル</item>
+        <item>サルノリ</item>
+        <item>バチンキー</item>
+        <item>ゴリランダー</item>
+        <item>ヒバニー</item>
+        <item>ラビフット</item>
+        <item>エースバーン</item>
+        <item>メッソン</item>
+        <item>ジメレオン</item>
+        <item>インテレオン</item>
+        <item>ホシガリス</item>
+        <item>ヨクバリス</item>
+        <item>ココガラ</item>
+        <item>アオガラス</item>
+        <item>アーマーガア</item>
+        <item>サッチムシ</item>
+        <item>レドームシ</item>
+        <item>イオルブ</item>
+        <item>クスネ</item>
+        <item>フォクスライ</item>
+        <item>ヒメンカ</item>
+        <item>ワタシラガ</item>
+        <item>ウールー</item>
+        <item>バイウールー</item>
+        <item>カムカメ</item>
+        <item>カジリガメ</item>
+        <item>ワンパチ</item>
+        <item>パルスワン</item>
+        <item>タンドン</item>
+        <item>トロッゴン</item>
+        <item>セキタンザン</item>
+        <item>カジッチュ</item>
+        <item>アップリュー</item>
+        <item>タルップル</item>
+        <item>スナヘビ</item>
+        <item>サダイジャ</item>
+        <item>ウッウ</item>
+        <item>サシカマス</item>
+        <item>カマスジョー</item>
+        <item>エレズン</item>
+        <item>ストリンダー</item>
+        <item>ヤクデ</item>
+        <item>マルヤクデ</item>
+        <item>タタッコ</item>
+        <item>オトスパス</item>
+        <item>ヤバチャ</item>
+        <item>ポットデス</item>
+        <item>ミブリム</item>
+        <item>テブリム</item>
+        <item>ブリムオン</item>
+        <item>ベロバー</item>
+        <item>ギモー</item>
+        <item>オーロンゲ</item>
         <item>タチフサグマ</item>
         <item>ニャイキング</item>
+        <item>サニゴーン</item>
         <item>ネギガナイト</item>
         <item>バリコオル</item>
         <item>デスバーン</item>
+        <item>マホミル</item>
+        <item>マホイップ</item>
+        <item>タイレーツ</item>
+        <item>バチンウニ</item>
+        <item>ユキハミ</item>
+        <item>モスノウ</item>
+        <item>イシヘンジン</item>
+        <item>コオリッポ</item>
+        <item>イエッサン</item>
+        <item>モルペコ</item>
+        <item>ゾウドウ</item>
+        <item>ダイオウドウ</item>
+        <item>パッチラゴン</item>
+        <item>パッチルドン</item>
+        <item>ウオノラゴン</item>
+        <item>ウオチルドン</item>
+        <item>ジュラルドン</item>
+        <item>ドラメシヤ</item>
+        <item>ドロンチ</item>
+        <item>ドラパルト</item>
+        <item>ザシアン</item>
+        <item>ザマゼンタ</item>
+        <item>ムゲンダイナ</item>
+        <item>ダクマ</item>
+        <item>ウーラオス</item>
+        <item>ザルード</item>
+        <item>レジエレキ</item>
+        <item>レジドラゴ</item>
+        <item>ブリザポス</item>
+        <item>レイスポス</item>
+        <item>バドレックス</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ko/pokemons.xml
+++ b/app/src/main/res/values-ko/pokemons.xml
@@ -715,12 +715,99 @@
         <item>음번</item>
         <item>제르네아스</item>
         <item>이벨타르</item>
+        <item>디안시</item>
+        <item>후파</item>
+        <item>볼케니온</item>
         <item>멜탄</item>
         <item>멜메탈</item>
+        <item>흥나숭</item>
+        <item>채키몽</item>
+        <item>고릴타</item>
+        <item>염버니</item>
+        <item>래비풋</item>
+        <item>에이스번</item>
+        <item>울머기</item>
+        <item>누겔레온</item>
+        <item>인텔리레온</item>
+        <item>탐리스</item>
+        <item>요씽리스</item>
+        <item>파라꼬</item>
+        <item>파크로우</item>
+        <item>아머까오</item>
+        <item>두루지벌레</item>
+        <item>레돔벌레</item>
+        <item>이올브</item>
+        <item>훔처우</item>
+        <item>폭슬라이</item>
+        <item>꼬모카</item>
+        <item>백솜모카</item>
+        <item>우르</item>
+        <item>배우르</item>
+        <item>깨물부기</item>
+        <item>갈가부기</item>
+        <item>멍파치</item>
+        <item>펄스멍</item>
+        <item>탄동</item>
+        <item>탄차곤</item>
+        <item>석탄산</item>
+        <item>과사삭벌레</item>
+        <item>애프룡</item>
+        <item>단지래플</item>
+        <item>모래뱀</item>
+        <item>사다이사</item>
+        <item>윽우지</item>
+        <item>찌로꼬치</item>
+        <item>꼬치조</item>
+        <item>일레즌</item>
+        <item>스트린더</item>
+        <item>태우지네</item>
+        <item>다태우지네</item>
+        <item>때때무노</item>
+        <item>케오퍼스</item>
+        <item>데인차</item>
+        <item>포트데스</item>
+        <item>몸지브림</item>
+        <item>손지브림</item>
+        <item>브리무음</item>
+        <item>메롱꿍</item>
+        <item>쏘겨모</item>
+        <item>오롱털</item>
         <item>가로막구리</item>
         <item>나이킹</item>
+        <item>산호르곤</item>
         <item>창파나이트</item>
         <item>마임꽁꽁</item>
         <item>데스판</item>
+        <item>마빌크</item>
+        <item>마휘핑</item>
+        <item>대여르</item>
+        <item>찌르성게</item>
+        <item>누니머기</item>
+        <item>모스노우</item>
+        <item>돌헨진</item>
+        <item>빙큐보</item>
+        <item>에써르</item>
+        <item>모르페코</item>
+        <item>끼리동</item>
+        <item>대왕끼리동</item>
+        <item>파치래곤</item>
+        <item>파치르돈</item>
+        <item>어래곤</item>
+        <item>어치르돈</item>
+        <item>두랄루돈</item>
+        <item>드라꼰</item>
+        <item>드래런치</item>
+        <item>드래펄트</item>
+        <item>자시안</item>
+        <item>자마젠타</item>
+        <item>무한다이노</item>
+        <item>치고마</item>
+        <item>우라오스</item>
+        <item>자루도</item>
+        <item>레지에레키</item>
+        <item>레지드래고</item>
+        <item>블리자포스</item>
+        <item>레이스포스</item>
+        <item>버드렉스</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-ko/pokemons.xml
+++ b/app/src/main/res/values-ko/pokemons.xml
@@ -679,6 +679,9 @@
         <item>트리미앙</item>
         <item>냐스퍼</item>
         <item>냐오닉스</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>슈쁘</item>
         <item>프레프티르</item>
         <item>나룸퍼프</item>
@@ -715,9 +718,96 @@
         <item>음번</item>
         <item>제르네아스</item>
         <item>이벨타르</item>
+        <item>Placeholder</item>
         <item>디안시</item>
         <item>후파</item>
         <item>볼케니온</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>멜탄</item>
         <item>멜메탈</item>
         <item>흥나숭</item>

--- a/app/src/main/res/values-zh-rCN/pokemons.xml
+++ b/app/src/main/res/values-zh-rCN/pokemons.xml
@@ -679,6 +679,9 @@
         <item>多丽米亚</item>
         <item>妙喵</item>
         <item>超能妙喵</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>粉香香</item>
         <item>芳香精</item>
         <item>绵绵泡芙</item>
@@ -715,9 +718,96 @@
         <item>音波龙</item>
         <item>哲尔尼亚斯</item>
         <item>伊裴尔塔尔</item>
+        <item>Placeholder</item>
         <item>蒂安希</item>
         <item>胡帕</item>
         <item>波尔凯尼恩</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>美录坦</item>
         <item>美录梅塔</item>
         <item>敲音猴</item>

--- a/app/src/main/res/values-zh-rCN/pokemons.xml
+++ b/app/src/main/res/values-zh-rCN/pokemons.xml
@@ -715,12 +715,99 @@
         <item>音波龙</item>
         <item>哲尔尼亚斯</item>
         <item>伊裴尔塔尔</item>
+        <item>蒂安希</item>
+        <item>胡帕</item>
+        <item>波尔凯尼恩</item>
         <item>美录坦</item>
         <item>美录梅塔</item>
+        <item>敲音猴</item>
+        <item>啪咚猴</item>
+        <item>轰擂金刚猩</item>
+        <item>炎兔儿</item>
+        <item>腾蹴小将</item>
+        <item>闪焰王牌</item>
+        <item>泪眼蜥</item>
+        <item>变涩蜥</item>
+        <item>千面避役</item>
+        <item>贪心栗鼠</item>
+        <item>藏饱栗鼠</item>
+        <item>稚山雀</item>
+        <item>蓝鸦</item>
+        <item>钢铠鸦</item>
+        <item>索侦虫</item>
+        <item>天罩虫</item>
+        <item>以欧路普</item>
+        <item>偷儿狐</item>
+        <item>狐大盗</item>
+        <item>幼棉棉</item>
+        <item>白蓬蓬</item>
+        <item>毛辫羊</item>
+        <item>毛毛角羊</item>
+        <item>咬咬龟</item>
+        <item>暴噬龟</item>
+        <item>来电汪</item>
+        <item>逐电犬</item>
+        <item>小炭仔</item>
+        <item>大炭车</item>
+        <item>巨炭山</item>
+        <item>啃果虫</item>
+        <item>苹裹龙</item>
+        <item>丰蜜龙</item>
+        <item>沙包蛇</item>
+        <item>沙螺蟒</item>
+        <item>古月鸟</item>
+        <item>刺梭鱼</item>
+        <item>戽斗尖梭</item>
+        <item>毒电婴</item>
+        <item>颤弦蝾螈</item>
+        <item>烧火蚣</item>
+        <item>焚焰蚣</item>
+        <item>拳拳蛸</item>
+        <item>八爪武师</item>
+        <item>来悲茶</item>
+        <item>怖思壶</item>
+        <item>迷布莉姆</item>
+        <item>提布莉姆</item>
+        <item>布莉姆温</item>
+        <item>捣蛋小妖</item>
+        <item>诈唬魔</item>
+        <item>长毛巨魔</item>
         <item>堵拦熊</item>
         <item>喵头目</item>
+        <item>魔灵珊瑚</item>
         <item>葱游兵</item>
         <item>踏冰人偶</item>
         <item>死神板</item>
+        <item>小仙奶</item>
+        <item>霜奶仙</item>
+        <item>列阵兵</item>
+        <item>啪嚓海胆</item>
+        <item>雪吞虫</item>
+        <item>雪绒蛾</item>
+        <item>巨石丁</item>
+        <item>冰砌鹅</item>
+        <item>爱管侍</item>
+        <item>莫鲁贝可</item>
+        <item>铜象</item>
+        <item>大王铜象</item>
+        <item>雷鸟龙</item>
+        <item>雷鸟海兽</item>
+        <item>鳃鱼龙</item>
+        <item>鳃鱼海兽</item>
+        <item>铝钢龙</item>
+        <item>多龙梅西亚</item>
+        <item>多龙奇</item>
+        <item>多龙巴鲁托</item>
+        <item>苍响</item>
+        <item>藏玛然特</item>
+        <item>无极汰那</item>
+        <item>熊徒弟</item>
+        <item>武道熊师</item>
+        <item>萨戮德</item>
+        <item>雷吉艾勒奇</item>
+        <item>雷吉铎拉戈</item>
+        <item>雪暴马</item>
+        <item>灵幽马</item>
+        <item>蕾冠王</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/pokemons.xml
+++ b/app/src/main/res/values-zh-rTW/pokemons.xml
@@ -715,12 +715,99 @@
         <item>音波龍</item>
         <item>哲爾尼亞斯</item>
         <item>伊裴爾塔爾</item>
+        <item>蒂安希</item>
+        <item>胡帕</item>
+        <item>波爾凱尼恩</item>
         <item>美錄坦</item>
         <item>美錄梅塔</item>
+        <item>敲音猴</item>
+        <item>啪咚猴</item>
+        <item>轟擂金剛猩</item>
+        <item>炎兔兒</item>
+        <item>騰蹴小將</item>
+        <item>閃焰王牌</item>
+        <item>淚眼蜥</item>
+        <item>變澀蜥</item>
+        <item>千面避役</item>
+        <item>貪心栗鼠</item>
+        <item>藏飽栗鼠</item>
+        <item>稚山雀</item>
+        <item>藍鴉</item>
+        <item>鋼鎧鴉</item>
+        <item>索偵蟲</item>
+        <item>天罩蟲</item>
+        <item>以歐路普</item>
+        <item>偷兒狐</item>
+        <item>狐大盜</item>
+        <item>幼棉棉</item>
+        <item>白蓬蓬</item>
+        <item>毛辮羊</item>
+        <item>毛毛角羊</item>
+        <item>咬咬龜</item>
+        <item>暴噬龜</item>
+        <item>來電汪</item>
+        <item>逐電犬</item>
+        <item>小炭仔</item>
+        <item>大炭車</item>
+        <item>巨炭山</item>
+        <item>啃果蟲</item>
+        <item>蘋裹龍</item>
+        <item>豐蜜龍</item>
+        <item>沙包蛇</item>
+        <item>沙螺蟒</item>
+        <item>古月鳥</item>
+        <item>刺梭魚</item>
+        <item>戽斗尖梭</item>
+        <item>毒電嬰</item>
+        <item>顫弦蠑螈</item>
+        <item>燒火蚣</item>
+        <item>焚焰蚣</item>
+        <item>拳拳蛸</item>
+        <item>八爪武師</item>
+        <item>來悲茶</item>
+        <item>怖思壺</item>
+        <item>迷布莉姆</item>
+        <item>提布莉姆</item>
+        <item>布莉姆溫</item>
+        <item>搗蛋小妖</item>
+        <item>詐唬魔</item>
+        <item>長毛巨魔</item>
         <item>堵攔熊</item>
         <item>喵頭目</item>
+        <item>魔靈珊瑚</item>
         <item>蔥遊兵</item>
         <item>踏冰人偶</item>
         <item>死神板</item>
+        <item>小仙奶</item>
+        <item>霜奶仙</item>
+        <item>列陣兵</item>
+        <item>啪嚓海膽</item>
+        <item>雪吞蟲</item>
+        <item>雪絨蛾</item>
+        <item>巨石丁</item>
+        <item>冰砌鵝</item>
+        <item>愛管侍</item>
+        <item>莫魯貝可</item>
+        <item>銅象</item>
+        <item>大王銅象</item>
+        <item>雷鳥龍</item>
+        <item>雷鳥海獸</item>
+        <item>鰓魚龍</item>
+        <item>鰓魚海獸</item>
+        <item>鋁鋼龍</item>
+        <item>多龍梅西亞</item>
+        <item>多龍奇</item>
+        <item>多龍巴魯托</item>
+        <item>蒼響</item>
+        <item>藏瑪然特</item>
+        <item>無極汰那</item>
+        <item>熊徒弟</item>
+        <item>武道熊師</item>
+        <item>薩戮德</item>
+        <item>雷吉艾勒奇</item>
+        <item>雷吉鐸拉戈</item>
+        <item>雪暴馬</item>
+        <item>靈幽馬</item>
+        <item>蕾冠王</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values-zh-rTW/pokemons.xml
+++ b/app/src/main/res/values-zh-rTW/pokemons.xml
@@ -679,6 +679,9 @@
         <item>多麗米亞</item>
         <item>妙喵</item>
         <item>超能妙喵</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>粉香香</item>
         <item>芳香精</item>
         <item>綿綿泡芙</item>
@@ -715,9 +718,96 @@
         <item>音波龍</item>
         <item>哲爾尼亞斯</item>
         <item>伊裴爾塔爾</item>
+        <item>Placeholder</item>
         <item>蒂安希</item>
         <item>胡帕</item>
         <item>波爾凱尼恩</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>美錄坦</item>
         <item>美錄梅塔</item>
         <item>敲音猴</item>

--- a/app/src/main/res/values/forms.xml
+++ b/app/src/main/res/values/forms.xml
@@ -3,7 +3,7 @@
 <integer-array name="formsCount">
  <item>2</item> <!-- Rattata -->
  <item>2</item> <!-- Raticate -->
- <item>4</item> <!-- Pikachu -->
+ <item>8</item> <!-- Pikachu -->
  <item>2</item> <!-- Raichu -->
  <item>2</item> <!-- Sandshrew -->
  <item>2</item> <!-- Sandslash -->
@@ -18,8 +18,8 @@
  <item>2</item> <!-- Golem -->
  <item>2</item> <!-- Ponyta -->
  <item>2</item> <!-- Rapidash -->
- <item>2</item> <!-- Slowpoke -->
- <item>2</item> <!-- Slowbro -->
+ <item>3</item> <!-- Slowpoke -->
+ <item>3</item> <!-- Slowbro -->
  <item>2</item> <!-- Farfetchd -->
  <item>2</item> <!-- Grimer -->
  <item>2</item> <!-- Muk -->
@@ -29,6 +29,7 @@
  <item>2</item> <!-- Weezing -->
  <item>2</item> <!-- Mr Mime -->
  <item>2</item> <!-- Mewtwo -->
+ <item>2</item> <!-- Slowking -->
  <item>28</item> <!-- Unown -->
  <item>2</item> <!-- Delibird -->
  <item>2</item> <!-- Zigzagoon -->
@@ -66,12 +67,24 @@
  <item>2</item> <!-- Pyroar -->
  <item>10</item> <!-- Furfrou -->
  <item>2</item> <!-- Meowstic -->
+ <item>2</item> <!-- Hoopa -->
+ <item>2</item> <!-- Toxtricity -->
+ <item>2</item> <!-- Sinistea -->
+ <item>2</item> <!-- Polteageist -->
+ <item>2</item> <!-- Eiscue -->
+ <item>2</item> <!-- Indeedee -->
+ <item>2</item> <!-- Morpeko -->
+ <item>2</item> <!-- Zacian -->
+ <item>2</item> <!-- Zamazenta -->
+ <item>2</item> <!-- Eternatus -->
+ <item>2</item> <!-- Urshifu -->
+ <item>3</item> <!-- Calyrex -->
 </integer-array>
 <string-array name="formNames">
  <!-- Rattata -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Raticate -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Pikachu -->
- <item>Normal Form</item> <item>Costume 2020 Form</item> <item>Adventure Hat 2020 Form</item> <item>Winter 2020 Form</item> <!-- Raichu -->
+ <item>Normal Form</item> <item>Costume 2020 Form</item> <item>Adventure Hat 2020 Form</item> <item>Winter 2020 Form</item> <item>Kariyushi Form</item> <item>Pop Star Form</item> <item>Rock Star Form</item> <item>Flying 5th Anniv Form</item> <!-- Raichu -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Sandshrew -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Sandslash -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Vulpix -->
@@ -86,8 +99,8 @@
  <item>Normal Form</item> <item>Alola Form</item> <!-- Ponyta -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Rapidash -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Slowpoke -->
- <item>Normal Form</item> <item>2020 Form</item> <!-- Slowbro -->
- <item>Normal Form</item> <item>2021 Form</item> <!-- Farfetchd -->
+ <item>Normal Form</item> <item>2020 Form</item> <item>Galarian Form</item> <!-- Slowbro -->
+ <item>Normal Form</item> <item>2021 Form</item> <item>Galarian Form</item> <!-- Farfetchd -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Grimer -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Muk -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Gengar -->
@@ -96,7 +109,8 @@
  <item>Normal Form</item> <item>Alola Form</item> <!-- Weezing -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Mr Mime -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Mewtwo -->
- <item>Normal Form</item> <item>Armored Form</item> <!-- Unown -->
+ <item>Normal Form</item> <item>Armored Form</item> <!-- Slowking -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Unown -->
  <item>F Form</item> <item>A Form</item> <item>B Form</item> <item>C Form</item> <item>D Form</item> <item>E Form</item> <item>G Form</item> <item>H Form</item> <item>I Form</item> <item>J Form</item> <item>K Form</item> <item>L Form</item> <item>M Form</item> <item>N Form</item> <item>O Form</item> <item>P Form</item> <item>Q Form</item> <item>R Form</item> <item>S Form</item> <item>T Form</item> <item>U Form</item> <item>V Form</item> <item>W Form</item> <item>X Form</item> <item>Y Form</item> <item>Z Form</item> <item>Exclamation Point Form</item> <item>Question Mark Form</item> <!-- Delibird -->
  <item>Normal Form</item> <item>Winter 2020 Form</item> <!-- Zigzagoon -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Linoone -->
@@ -133,7 +147,19 @@
  <item>Normal Form</item> <item>Douse Form</item> <item>Shock Form</item> <item>Burn Form</item> <item>Chill Form</item> <!-- Pyroar -->
  <item>Normal Form</item> <item>Female Form</item> <!-- Furfrou -->
  <item>Natural Form</item> <item>Heart Form</item> <item>Star Form</item> <item>Diamond Form</item> <item>Debutante Form</item> <item>Matron Form</item> <item>Dandy Form</item> <item>La Reine Form</item> <item>Kabuki Form</item> <item>Pharaoh Form</item> <!-- Meowstic -->
- <item>Normal Form</item> <item>Female Form</item></string-array>
+ <item>Normal Form</item> <item>Female Form</item> <!-- Hoopa -->
+ <item>Confined Form</item> <item>Unbound Form</item> <!-- Toxtricity -->
+ <item>Low Key Form</item> <item>Amped Form</item> <!-- Sinistea -->
+ <item>Phony Form</item> <item>Antique Form</item> <!-- Polteageist -->
+ <item>Phony Form</item> <item>Antique Form</item> <!-- Eiscue -->
+ <item>Ice Form</item> <item>Noice Form</item> <!-- Indeedee -->
+ <item>Male Form</item> <item>Female Form</item> <!-- Morpeko -->
+ <item>Full Belly Form</item> <item>Hangry Form</item> <!-- Zacian -->
+ <item>Hero Form</item> <item>Crowned Sword Form</item> <!-- Zamazenta -->
+ <item>Hero Form</item> <item>Crowned Shield Form</item> <!-- Eternatus -->
+ <item>Normal Form</item> <item>Eternamax Form</item> <!-- Urshifu -->
+ <item>Single Strike Form</item> <item>Rapid Strike Form</item> <!-- Calyrex -->
+ <item>Normal Form</item> <item>Ice Rider Form</item> <item>Shadow Rider Form</item></string-array>
 <integer-array name="formAttack">
  <!-- Rattata -->
  <item>103</item> <!-- Normal Form -->
@@ -146,6 +172,10 @@
  <item>112</item> <!-- Costume 2020 Form -->
  <item>112</item> <!-- Adventure Hat 2020 Form -->
  <item>112</item> <!-- Winter 2020 Form -->
+ <item>112</item> <!-- Kariyushi Form -->
+ <item>112</item> <!-- Pop Star Form -->
+ <item>112</item> <!-- Rock Star Form -->
+ <item>112</item> <!-- Flying 5th Anniv Form -->
  <!-- Raichu -->
  <item>193</item> <!-- Normal Form -->
  <item>201</item> <!-- Alola Form -->
@@ -192,9 +222,11 @@
  <!-- Slowpoke -->
  <item>109</item> <!-- Normal Form -->
  <item>109</item> <!-- 2020 Form -->
+ <item>109</item> <!-- Galarian Form -->
  <!-- Slowbro -->
  <item>177</item> <!-- Normal Form -->
  <item>177</item> <!-- 2021 Form -->
+ <item>182</item> <!-- Galarian Form -->
  <!-- Farfetchd -->
  <item>124</item> <!-- Normal Form -->
  <item>174</item> <!-- Galarian Form -->
@@ -222,6 +254,9 @@
  <!-- Mewtwo -->
  <item>300</item> <!-- Normal Form -->
  <item>182</item> <!-- Armored Form -->
+ <!-- Slowking -->
+ <item>177</item> <!-- Normal Form -->
+ <item>190</item> <!-- Galarian Form -->
  <!-- Unown -->
  <item>136</item> <!-- F Form -->
  <item>136</item> <!-- A Form -->
@@ -421,6 +456,43 @@
  <!-- Meowstic -->
  <item>166</item> <!-- Normal Form -->
  <item>166</item> <!-- Female Form -->
+ <!-- Hoopa -->
+ <item>261</item> <!-- Confined Form -->
+ <item>311</item> <!-- Unbound Form -->
+ <!-- Toxtricity -->
+ <item>224</item> <!-- Low Key Form -->
+ <item>224</item> <!-- Amped Form -->
+ <!-- Sinistea -->
+ <item>134</item> <!-- Phony Form -->
+ <item>134</item> <!-- Antique Form -->
+ <!-- Polteageist -->
+ <item>248</item> <!-- Phony Form -->
+ <item>248</item> <!-- Antique Form -->
+ <!-- Eiscue -->
+ <item>148</item> <!-- Ice Form -->
+ <item>173</item> <!-- Noice Form -->
+ <!-- Indeedee -->
+ <item>208</item> <!-- Male Form -->
+ <item>184</item> <!-- Female Form -->
+ <!-- Morpeko -->
+ <item>192</item> <!-- Full Belly Form -->
+ <item>192</item> <!-- Hangry Form -->
+ <!-- Zacian -->
+ <item>254</item> <!-- Hero Form -->
+ <item>332</item> <!-- Crowned Sword Form -->
+ <!-- Zamazenta -->
+ <item>254</item> <!-- Hero Form -->
+ <item>250</item> <!-- Crowned Shield Form -->
+ <!-- Eternatus -->
+ <item>278</item> <!-- Normal Form -->
+ <item>251</item> <!-- Eternamax Form -->
+ <!-- Urshifu -->
+ <item>254</item> <!-- Single Strike Form -->
+ <item>254</item> <!-- Rapid Strike Form -->
+ <!-- Calyrex -->
+ <item>162</item> <!-- Normal Form -->
+ <item>268</item> <!-- Ice Rider Form -->
+ <item>324</item> <!-- Shadow Rider Form -->
 </integer-array>
 <integer-array name="formDefense">
  <!-- Rattata -->
@@ -434,6 +506,10 @@
  <item>96</item> <!-- Costume 2020 Form -->
  <item>96</item> <!-- Adventure Hat 2020 Form -->
  <item>96</item> <!-- Winter 2020 Form -->
+ <item>96</item> <!-- Kariyushi Form -->
+ <item>96</item> <!-- Pop Star Form -->
+ <item>96</item> <!-- Rock Star Form -->
+ <item>96</item> <!-- Flying 5th Anniv Form -->
  <!-- Raichu -->
  <item>151</item> <!-- Normal Form -->
  <item>154</item> <!-- Alola Form -->
@@ -480,9 +556,11 @@
  <!-- Slowpoke -->
  <item>98</item> <!-- Normal Form -->
  <item>98</item> <!-- 2020 Form -->
+ <item>98</item> <!-- Galarian Form -->
  <!-- Slowbro -->
  <item>180</item> <!-- Normal Form -->
  <item>180</item> <!-- 2021 Form -->
+ <item>156</item> <!-- Galarian Form -->
  <!-- Farfetchd -->
  <item>115</item> <!-- Normal Form -->
  <item>114</item> <!-- Galarian Form -->
@@ -510,6 +588,9 @@
  <!-- Mewtwo -->
  <item>182</item> <!-- Normal Form -->
  <item>278</item> <!-- Armored Form -->
+ <!-- Slowking -->
+ <item>180</item> <!-- Normal Form -->
+ <item>180</item> <!-- Galarian Form -->
  <!-- Unown -->
  <item>91</item> <!-- F Form -->
  <item>91</item> <!-- A Form -->
@@ -709,6 +790,43 @@
  <!-- Meowstic -->
  <item>167</item> <!-- Normal Form -->
  <item>167</item> <!-- Female Form -->
+ <!-- Hoopa -->
+ <item>187</item> <!-- Confined Form -->
+ <item>191</item> <!-- Unbound Form -->
+ <!-- Toxtricity -->
+ <item>140</item> <!-- Low Key Form -->
+ <item>140</item> <!-- Amped Form -->
+ <!-- Sinistea -->
+ <item>96</item> <!-- Phony Form -->
+ <item>96</item> <!-- Antique Form -->
+ <!-- Polteageist -->
+ <item>189</item> <!-- Phony Form -->
+ <item>189</item> <!-- Antique Form -->
+ <!-- Eiscue -->
+ <item>195</item> <!-- Ice Form -->
+ <item>139</item> <!-- Noice Form -->
+ <!-- Indeedee -->
+ <item>166</item> <!-- Male Form -->
+ <item>184</item> <!-- Female Form -->
+ <!-- Morpeko -->
+ <item>121</item> <!-- Full Belly Form -->
+ <item>121</item> <!-- Hangry Form -->
+ <!-- Zacian -->
+ <item>236</item> <!-- Hero Form -->
+ <item>240</item> <!-- Crowned Sword Form -->
+ <!-- Zamazenta -->
+ <item>236</item> <!-- Hero Form -->
+ <item>292</item> <!-- Crowned Shield Form -->
+ <!-- Eternatus -->
+ <item>192</item> <!-- Normal Form -->
+ <item>505</item> <!-- Eternamax Form -->
+ <!-- Urshifu -->
+ <item>177</item> <!-- Single Strike Form -->
+ <item>177</item> <!-- Rapid Strike Form -->
+ <!-- Calyrex -->
+ <item>162</item> <!-- Normal Form -->
+ <item>246</item> <!-- Ice Rider Form -->
+ <item>194</item> <!-- Shadow Rider Form -->
 </integer-array>
 <integer-array name="formStamina">
  <!-- Rattata -->
@@ -722,6 +840,10 @@
  <item>111</item> <!-- Costume 2020 Form -->
  <item>111</item> <!-- Adventure Hat 2020 Form -->
  <item>111</item> <!-- Winter 2020 Form -->
+ <item>111</item> <!-- Kariyushi Form -->
+ <item>111</item> <!-- Pop Star Form -->
+ <item>111</item> <!-- Rock Star Form -->
+ <item>111</item> <!-- Flying 5th Anniv Form -->
  <!-- Raichu -->
  <item>155</item> <!-- Normal Form -->
  <item>155</item> <!-- Alola Form -->
@@ -768,9 +890,11 @@
  <!-- Slowpoke -->
  <item>207</item> <!-- Normal Form -->
  <item>207</item> <!-- 2020 Form -->
+ <item>207</item> <!-- Galarian Form -->
  <!-- Slowbro -->
  <item>216</item> <!-- Normal Form -->
  <item>216</item> <!-- 2021 Form -->
+ <item>216</item> <!-- Galarian Form -->
  <!-- Farfetchd -->
  <item>141</item> <!-- Normal Form -->
  <item>141</item> <!-- Galarian Form -->
@@ -798,6 +922,9 @@
  <!-- Mewtwo -->
  <item>214</item> <!-- Normal Form -->
  <item>214</item> <!-- Armored Form -->
+ <!-- Slowking -->
+ <item>216</item> <!-- Normal Form -->
+ <item>216</item> <!-- Galarian Form -->
  <!-- Unown -->
  <item>134</item> <!-- F Form -->
  <item>134</item> <!-- A Form -->
@@ -997,5 +1124,42 @@
  <!-- Meowstic -->
  <item>179</item> <!-- Normal Form -->
  <item>179</item> <!-- Female Form -->
+ <!-- Hoopa -->
+ <item>173</item> <!-- Confined Form -->
+ <item>173</item> <!-- Unbound Form -->
+ <!-- Toxtricity -->
+ <item>181</item> <!-- Low Key Form -->
+ <item>181</item> <!-- Amped Form -->
+ <!-- Sinistea -->
+ <item>120</item> <!-- Phony Form -->
+ <item>120</item> <!-- Antique Form -->
+ <!-- Polteageist -->
+ <item>155</item> <!-- Phony Form -->
+ <item>155</item> <!-- Antique Form -->
+ <!-- Eiscue -->
+ <item>181</item> <!-- Ice Form -->
+ <item>181</item> <!-- Noice Form -->
+ <!-- Indeedee -->
+ <item>155</item> <!-- Male Form -->
+ <item>172</item> <!-- Female Form -->
+ <!-- Morpeko -->
+ <item>151</item> <!-- Full Belly Form -->
+ <item>151</item> <!-- Hangry Form -->
+ <!-- Zacian -->
+ <item>192</item> <!-- Hero Form -->
+ <item>192</item> <!-- Crowned Sword Form -->
+ <!-- Zamazenta -->
+ <item>192</item> <!-- Hero Form -->
+ <item>192</item> <!-- Crowned Shield Form -->
+ <!-- Eternatus -->
+ <item>268</item> <!-- Normal Form -->
+ <item>452</item> <!-- Eternamax Form -->
+ <!-- Urshifu -->
+ <item>225</item> <!-- Single Strike Form -->
+ <item>225</item> <!-- Rapid Strike Form -->
+ <!-- Calyrex -->
+ <item>225</item> <!-- Normal Form -->
+ <item>205</item> <!-- Ice Rider Form -->
+ <item>205</item> <!-- Shadow Rider Form -->
 </integer-array>
 </resources>

--- a/app/src/main/res/values/forms.xml
+++ b/app/src/main/res/values/forms.xml
@@ -81,85 +81,85 @@
  <item>3</item> <!-- Calyrex -->
 </integer-array>
 <string-array name="formNames">
- <!-- Rattata -->
+ <item>Normal Form</item> <item>Alola Form</item> <!-- Rattata -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Raticate -->
- <item>Normal Form</item> <item>Alola Form</item> <!-- Pikachu -->
- <item>Normal Form</item> <item>Costume 2020 Form</item> <item>Adventure Hat 2020 Form</item> <item>Winter 2020 Form</item> <item>Kariyushi Form</item> <item>Pop Star Form</item> <item>Rock Star Form</item> <item>Flying 5th Anniv Form</item> <!-- Raichu -->
+ <item>Normal Form</item> <item>Costume 2020 Form</item> <item>Adventure Hat 2020 Form</item> <item>Winter 2020 Form</item> <item>Kariyushi Form</item> <item>Pop Star Form</item> <item>Rock Star Form</item> <item>Flying 5th Anniv Form</item> <!-- Pikachu -->
+ <item>Normal Form</item> <item>Alola Form</item> <!-- Raichu -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Sandshrew -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Sandslash -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Vulpix -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Ninetales -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Diglett -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Dugtrio -->
- <item>Normal Form</item> <item>Alola Form</item> <!-- Meowth -->
- <item>Normal Form</item> <item>Alola Form</item> <item>Galarian Form</item> <!-- Persian -->
+ <item>Normal Form</item> <item>Alola Form</item> <item>Galarian Form</item> <!-- Meowth -->
+ <item>Normal Form</item> <item>Alola Form</item> <!-- Persian -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Geodude -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Graveler -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Golem -->
- <item>Normal Form</item> <item>Alola Form</item> <!-- Ponyta -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Ponyta -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Rapidash -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Slowpoke -->
- <item>Normal Form</item> <item>2020 Form</item> <item>Galarian Form</item> <!-- Slowbro -->
- <item>Normal Form</item> <item>2021 Form</item> <item>Galarian Form</item> <!-- Farfetchd -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Grimer -->
+ <item>Normal Form</item> <item>2020 Form</item> <item>Galarian Form</item> <!-- Slowpoke -->
+ <item>Normal Form</item> <item>2021 Form</item> <item>Galarian Form</item> <!-- Slowbro -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Farfetchd -->
+ <item>Normal Form</item> <item>Alola Form</item> <!-- Grimer -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Muk -->
- <item>Normal Form</item> <item>Alola Form</item> <!-- Gengar -->
- <item>Normal Form</item> <item>Costume 2020 Form</item> <!-- Exeggutor -->
+ <item>Normal Form</item> <item>Costume 2020 Form</item> <!-- Gengar -->
+ <item>Normal Form</item> <item>Alola Form</item> <!-- Exeggutor -->
  <item>Normal Form</item> <item>Alola Form</item> <!-- Marowak -->
- <item>Normal Form</item> <item>Alola Form</item> <!-- Weezing -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Weezing -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Mr Mime -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Mewtwo -->
- <item>Normal Form</item> <item>Armored Form</item> <!-- Slowking -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Unown -->
- <item>F Form</item> <item>A Form</item> <item>B Form</item> <item>C Form</item> <item>D Form</item> <item>E Form</item> <item>G Form</item> <item>H Form</item> <item>I Form</item> <item>J Form</item> <item>K Form</item> <item>L Form</item> <item>M Form</item> <item>N Form</item> <item>O Form</item> <item>P Form</item> <item>Q Form</item> <item>R Form</item> <item>S Form</item> <item>T Form</item> <item>U Form</item> <item>V Form</item> <item>W Form</item> <item>X Form</item> <item>Y Form</item> <item>Z Form</item> <item>Exclamation Point Form</item> <item>Question Mark Form</item> <!-- Delibird -->
- <item>Normal Form</item> <item>Winter 2020 Form</item> <!-- Zigzagoon -->
+ <item>Normal Form</item> <item>Armored Form</item> <!-- Mewtwo -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Slowking -->
+ <item>F Form</item> <item>A Form</item> <item>B Form</item> <item>C Form</item> <item>D Form</item> <item>E Form</item> <item>G Form</item> <item>H Form</item> <item>I Form</item> <item>J Form</item> <item>K Form</item> <item>L Form</item> <item>M Form</item> <item>N Form</item> <item>O Form</item> <item>P Form</item> <item>Q Form</item> <item>R Form</item> <item>S Form</item> <item>T Form</item> <item>U Form</item> <item>V Form</item> <item>W Form</item> <item>X Form</item> <item>Y Form</item> <item>Z Form</item> <item>Exclamation Point Form</item> <item>Question Mark Form</item> <!-- Unown -->
+ <item>Normal Form</item> <item>Winter 2020 Form</item> <!-- Delibird -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Zigzagoon -->
  <item>Normal Form</item> <item>Galarian Form</item> <!-- Linoone -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Sableye -->
- <item>Normal Form</item> <item>Costume 2020 Form</item> <!-- Spinda -->
- <item>00 Form</item> <item>01 Form</item> <item>02 Form</item> <item>03 Form</item> <item>04 Form</item> <item>05 Form</item> <item>06 Form</item> <item>07 Form</item> <item>08 Form</item> <item>09 Form</item> <item>10 Form</item> <item>11 Form</item> <item>12 Form</item> <item>13 Form</item> <item>14 Form</item> <item>15 Form</item> <item>16 Form</item> <item>17 Form</item> <item>18 Form</item> <item>19 Form</item> <!-- Castform -->
- <item>Normal Form</item> <item>Sunny Form</item> <item>Rainy Form</item> <item>Snowy Form</item> <!-- Deoxys -->
- <item>Normal Form</item> <item>Attack Form</item> <item>Defense Form</item> <item>Speed Form</item> <!-- Burmy -->
+ <item>Normal Form</item> <item>Costume 2020 Form</item> <!-- Sableye -->
+ <item>00 Form</item> <item>01 Form</item> <item>02 Form</item> <item>03 Form</item> <item>04 Form</item> <item>05 Form</item> <item>06 Form</item> <item>07 Form</item> <item>08 Form</item> <item>09 Form</item> <item>10 Form</item> <item>11 Form</item> <item>12 Form</item> <item>13 Form</item> <item>14 Form</item> <item>15 Form</item> <item>16 Form</item> <item>17 Form</item> <item>18 Form</item> <item>19 Form</item> <!-- Spinda -->
+ <item>Normal Form</item> <item>Sunny Form</item> <item>Rainy Form</item> <item>Snowy Form</item> <!-- Castform -->
+ <item>Normal Form</item> <item>Attack Form</item> <item>Defense Form</item> <item>Speed Form</item> <!-- Deoxys -->
+ <item>Plant Form</item> <item>Sandy Form</item> <item>Trash Form</item> <!-- Burmy -->
  <item>Plant Form</item> <item>Sandy Form</item> <item>Trash Form</item> <!-- Wormadam -->
- <item>Plant Form</item> <item>Sandy Form</item> <item>Trash Form</item> <!-- Cherrim -->
- <item>Overcast Form</item> <item>Sunny Form</item> <!-- Shellos -->
+ <item>Overcast Form</item> <item>Sunny Form</item> <!-- Cherrim -->
+ <item>West Sea Form</item> <item>East Sea Form</item> <!-- Shellos -->
  <item>West Sea Form</item> <item>East Sea Form</item> <!-- Gastrodon -->
- <item>West Sea Form</item> <item>East Sea Form</item> <!-- Rotom -->
- <item>Normal Form</item> <item>Heat Form</item> <item>Wash Form</item> <item>Frost Form</item> <item>Fan Form</item> <item>Mow Form</item> <!-- Giratina -->
- <item>Altered Form</item> <item>Origin Form</item> <!-- Shaymin -->
- <item>Land Form</item> <item>Sky Form</item> <!-- Arceus -->
- <item>Normal Form</item> <item>Fighting Form</item> <item>Flying Form</item> <item>Poison Form</item> <item>Ground Form</item> <item>Rock Form</item> <item>Bug Form</item> <item>Ghost Form</item> <item>Steel Form</item> <item>Fire Form</item> <item>Water Form</item> <item>Grass Form</item> <item>Electric Form</item> <item>Psychic Form</item> <item>Ice Form</item> <item>Dragon Form</item> <item>Dark Form</item> <item>Fairy Form</item> <!-- Basculin -->
- <item>Red Striped Form</item> <item>Blue Striped Form</item> <!-- Darumaka -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Darmanitan -->
- <item>Standard Form</item> <item>Zen Form</item> <item>Galarian Standard Form</item> <item>Galarian Zen Form</item> <!-- Yamask -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Deerling -->
+ <item>Normal Form</item> <item>Heat Form</item> <item>Wash Form</item> <item>Frost Form</item> <item>Fan Form</item> <item>Mow Form</item> <!-- Rotom -->
+ <item>Altered Form</item> <item>Origin Form</item> <!-- Giratina -->
+ <item>Land Form</item> <item>Sky Form</item> <!-- Shaymin -->
+ <item>Normal Form</item> <item>Fighting Form</item> <item>Flying Form</item> <item>Poison Form</item> <item>Ground Form</item> <item>Rock Form</item> <item>Bug Form</item> <item>Ghost Form</item> <item>Steel Form</item> <item>Fire Form</item> <item>Water Form</item> <item>Grass Form</item> <item>Electric Form</item> <item>Psychic Form</item> <item>Ice Form</item> <item>Dragon Form</item> <item>Dark Form</item> <item>Fairy Form</item> <!-- Arceus -->
+ <item>Red Striped Form</item> <item>Blue Striped Form</item> <!-- Basculin -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Darumaka -->
+ <item>Standard Form</item> <item>Zen Form</item> <item>Galarian Standard Form</item> <item>Galarian Zen Form</item> <!-- Darmanitan -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Yamask -->
+ <item>Spring Form</item> <item>Summer Form</item> <item>Autumn Form</item> <item>Winter Form</item> <!-- Deerling -->
  <item>Spring Form</item> <item>Summer Form</item> <item>Autumn Form</item> <item>Winter Form</item> <!-- Sawsbuck -->
- <item>Spring Form</item> <item>Summer Form</item> <item>Autumn Form</item> <item>Winter Form</item> <!-- Frillish -->
+ <item>Normal Form</item> <item>Female Form</item> <!-- Frillish -->
  <item>Normal Form</item> <item>Female Form</item> <!-- Jellicent -->
- <item>Normal Form</item> <item>Female Form</item> <!-- Cubchoo -->
- <item>Normal Form</item> <item>Winter 2020 Form</item> <!-- Stunfisk -->
- <item>Normal Form</item> <item>Galarian Form</item> <!-- Tornadus -->
+ <item>Normal Form</item> <item>Winter 2020 Form</item> <!-- Cubchoo -->
+ <item>Normal Form</item> <item>Galarian Form</item> <!-- Stunfisk -->
+ <item>Incarnate Form</item> <item>Therian Form</item> <!-- Tornadus -->
  <item>Incarnate Form</item> <item>Therian Form</item> <!-- Thundurus -->
  <item>Incarnate Form</item> <item>Therian Form</item> <!-- Landorus -->
- <item>Incarnate Form</item> <item>Therian Form</item> <!-- Kyurem -->
- <item>Normal Form</item> <item>White Form</item> <item>Black Form</item> <!-- Keldeo -->
- <item>Ordinary Form</item> <item>Resolute Form</item> <!-- Meloetta -->
- <item>Aria Form</item> <item>Pirouette Form</item> <!-- Genesect -->
- <item>Normal Form</item> <item>Douse Form</item> <item>Shock Form</item> <item>Burn Form</item> <item>Chill Form</item> <!-- Pyroar -->
- <item>Normal Form</item> <item>Female Form</item> <!-- Furfrou -->
- <item>Natural Form</item> <item>Heart Form</item> <item>Star Form</item> <item>Diamond Form</item> <item>Debutante Form</item> <item>Matron Form</item> <item>Dandy Form</item> <item>La Reine Form</item> <item>Kabuki Form</item> <item>Pharaoh Form</item> <!-- Meowstic -->
- <item>Normal Form</item> <item>Female Form</item> <!-- Hoopa -->
- <item>Confined Form</item> <item>Unbound Form</item> <!-- Toxtricity -->
- <item>Low Key Form</item> <item>Amped Form</item> <!-- Sinistea -->
+ <item>Normal Form</item> <item>White Form</item> <item>Black Form</item> <!-- Kyurem -->
+ <item>Ordinary Form</item> <item>Resolute Form</item> <!-- Keldeo -->
+ <item>Aria Form</item> <item>Pirouette Form</item> <!-- Meloetta -->
+ <item>Normal Form</item> <item>Douse Form</item> <item>Shock Form</item> <item>Burn Form</item> <item>Chill Form</item> <!-- Genesect -->
+ <item>Normal Form</item> <item>Female Form</item> <!-- Pyroar -->
+ <item>Natural Form</item> <item>Heart Form</item> <item>Star Form</item> <item>Diamond Form</item> <item>Debutante Form</item> <item>Matron Form</item> <item>Dandy Form</item> <item>La Reine Form</item> <item>Kabuki Form</item> <item>Pharaoh Form</item> <!-- Furfrou -->
+ <item>Normal Form</item> <item>Female Form</item> <!-- Meowstic -->
+ <item>Confined Form</item> <item>Unbound Form</item> <!-- Hoopa -->
+ <item>Low Key Form</item> <item>Amped Form</item> <!-- Toxtricity -->
+ <item>Phony Form</item> <item>Antique Form</item> <!-- Sinistea -->
  <item>Phony Form</item> <item>Antique Form</item> <!-- Polteageist -->
- <item>Phony Form</item> <item>Antique Form</item> <!-- Eiscue -->
- <item>Ice Form</item> <item>Noice Form</item> <!-- Indeedee -->
- <item>Male Form</item> <item>Female Form</item> <!-- Morpeko -->
- <item>Full Belly Form</item> <item>Hangry Form</item> <!-- Zacian -->
- <item>Hero Form</item> <item>Crowned Sword Form</item> <!-- Zamazenta -->
- <item>Hero Form</item> <item>Crowned Shield Form</item> <!-- Eternatus -->
- <item>Normal Form</item> <item>Eternamax Form</item> <!-- Urshifu -->
- <item>Single Strike Form</item> <item>Rapid Strike Form</item> <!-- Calyrex -->
- <item>Normal Form</item> <item>Ice Rider Form</item> <item>Shadow Rider Form</item></string-array>
+ <item>Ice Form</item> <item>Noice Form</item> <!-- Eiscue -->
+ <item>Male Form</item> <item>Female Form</item> <!-- Indeedee -->
+ <item>Full Belly Form</item> <item>Hangry Form</item> <!-- Morpeko -->
+ <item>Hero Form</item> <item>Crowned Sword Form</item> <!-- Zacian -->
+ <item>Hero Form</item> <item>Crowned Shield Form</item> <!-- Zamazenta -->
+ <item>Normal Form</item> <item>Eternamax Form</item> <!-- Eternatus -->
+ <item>Single Strike Form</item> <item>Rapid Strike Form</item> <!-- Urshifu -->
+ <item>Normal Form</item> <item>Ice Rider Form</item> <item>Shadow Rider Form</item> <!-- Calyrex -->
+</string-array>
 <integer-array name="formAttack">
  <!-- Rattata -->
  <item>103</item> <!-- Normal Form -->

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -715,13 +715,100 @@
  <item>205</item> <!-- Noivern -->
  <item>250</item> <!-- Xerneas -->
  <item>250</item> <!-- Yveltal -->
+ <item>190</item> <!-- Diancie -->
+ <item>261</item> <!-- Hoopa -->
+ <item>252</item> <!-- Volcanion -->
  <item>118</item> <!-- Meltan -->
  <item>226</item> <!-- Melmetal -->
+ <item>122</item> <!-- Grookey -->
+ <item>165</item> <!-- Thwackey -->
+ <item>239</item> <!-- Rillaboom -->
+ <item>132</item> <!-- Scorbunny -->
+ <item>170</item> <!-- Raboot -->
+ <item>238</item> <!-- Cinderace -->
+ <item>132</item> <!-- Sobble -->
+ <item>186</item> <!-- Drizzile -->
+ <item>262</item> <!-- Inteleon -->
+ <item>95</item> <!-- Skwovet -->
+ <item>160</item> <!-- Greedent -->
+ <item>88</item> <!-- Rookidee -->
+ <item>129</item> <!-- Corvisquire -->
+ <item>163</item> <!-- Corviknight -->
+ <item>46</item> <!-- Blipbug -->
+ <item>87</item> <!-- Dottler -->
+ <item>156</item> <!-- Orbeetle -->
+ <item>85</item> <!-- Nickit -->
+ <item>172</item> <!-- Thievul -->
+ <item>70</item> <!-- Gossifleur -->
+ <item>148</item> <!-- Eldegoss -->
+ <item>76</item> <!-- Wooloo -->
+ <item>159</item> <!-- Dubwool -->
+ <item>114</item> <!-- Chewtle -->
+ <item>213</item> <!-- Drednaw -->
+ <item>80</item> <!-- Yamper -->
+ <item>197</item> <!-- Boltund -->
+ <item>73</item> <!-- Rolycoly -->
+ <item>114</item> <!-- Carkol -->
+ <item>146</item> <!-- Coalossal -->
+ <item>71</item> <!-- Applin -->
+ <item>214</item> <!-- Flapple -->
+ <item>178</item> <!-- Appletun -->
+ <item>103</item> <!-- Silicobra -->
+ <item>202</item> <!-- Sandaconda -->
+ <item>173</item> <!-- Cramorant -->
+ <item>118</item> <!-- Arrokuda -->
+ <item>258</item> <!-- Barraskewda -->
+ <item>97</item> <!-- Toxel -->
+ <item>224</item> <!-- Toxtricity -->
+ <item>118</item> <!-- Sizzlipede -->
+ <item>220</item> <!-- Centiskorch -->
+ <item>121</item> <!-- Clobbopus -->
+ <item>209</item> <!-- Grapploct -->
+ <item>134</item> <!-- Sinistea -->
+ <item>248</item> <!-- Polteageist -->
+ <item>98</item> <!-- Hatenna -->
+ <item>153</item> <!-- Hattrem -->
+ <item>237</item> <!-- Hatterene -->
+ <item>103</item> <!-- Impidimp -->
+ <item>145</item> <!-- Morgrem -->
+ <item>227</item> <!-- Grimmsnarl -->
  <item>180</item> <!-- Obstagoon -->
  <item>195</item> <!-- Perrserker -->
+ <item>253</item> <!-- Cursola -->
  <item>248</item> <!-- Sirfetchd -->
  <item>212</item> <!-- Mr Rime -->
  <item>163</item> <!-- Runerigus -->
+ <item>90</item> <!-- Milcery -->
+ <item>203</item> <!-- Alcremie -->
+ <item>193</item> <!-- Falinks -->
+ <item>176</item> <!-- Pincurchin -->
+ <item>76</item> <!-- Snom -->
+ <item>230</item> <!-- Frosmoth -->
+ <item>222</item> <!-- Stonjourner -->
+ <item>148</item> <!-- Eiscue -->
+ <item>208</item> <!-- Indeedee -->
+ <item>192</item> <!-- Morpeko -->
+ <item>140</item> <!-- Cufant -->
+ <item>226</item> <!-- Copperajah -->
+ <item>195</item> <!-- Dracozolt -->
+ <item>190</item> <!-- Arctozolt -->
+ <item>175</item> <!-- Dracovish -->
+ <item>171</item> <!-- Arctovish -->
+ <item>239</item> <!-- Duraludon -->
+ <item>117</item> <!-- Dreepy -->
+ <item>163</item> <!-- Drakloak -->
+ <item>266</item> <!-- Dragapult -->
+ <item>254</item> <!-- Zacian -->
+ <item>254</item> <!-- Zamazenta -->
+ <item>278</item> <!-- Eternatus -->
+ <item>170</item> <!-- Kubfu -->
+ <item>254</item> <!-- Urshifu -->
+ <item>242</item> <!-- Zarude -->
+ <item>250</item> <!-- Regieleki -->
+ <item>202</item> <!-- Regidrago -->
+ <item>246</item> <!-- Glastrier -->
+ <item>273</item> <!-- Spectrier -->
+ <item>162</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="defense">
  <item>111</item> <!-- Bulbasaur -->
@@ -1438,13 +1525,100 @@
  <item>175</item> <!-- Noivern -->
  <item>185</item> <!-- Xerneas -->
  <item>185</item> <!-- Yveltal -->
+ <item>285</item> <!-- Diancie -->
+ <item>187</item> <!-- Hoopa -->
+ <item>216</item> <!-- Volcanion -->
  <item>99</item> <!-- Meltan -->
  <item>190</item> <!-- Melmetal -->
+ <item>91</item> <!-- Grookey -->
+ <item>134</item> <!-- Thwackey -->
+ <item>168</item> <!-- Rillaboom -->
+ <item>79</item> <!-- Scorbunny -->
+ <item>125</item> <!-- Raboot -->
+ <item>163</item> <!-- Cinderace -->
+ <item>79</item> <!-- Sobble -->
+ <item>113</item> <!-- Drizzile -->
+ <item>142</item> <!-- Inteleon -->
+ <item>86</item> <!-- Skwovet -->
+ <item>156</item> <!-- Greedent -->
+ <item>67</item> <!-- Rookidee -->
+ <item>110</item> <!-- Corvisquire -->
+ <item>192</item> <!-- Corviknight -->
+ <item>67</item> <!-- Blipbug -->
+ <item>157</item> <!-- Dottler -->
+ <item>240</item> <!-- Orbeetle -->
+ <item>82</item> <!-- Nickit -->
+ <item>164</item> <!-- Thievul -->
+ <item>104</item> <!-- Gossifleur -->
+ <item>211</item> <!-- Eldegoss -->
+ <item>97</item> <!-- Wooloo -->
+ <item>198</item> <!-- Dubwool -->
+ <item>85</item> <!-- Chewtle -->
+ <item>164</item> <!-- Drednaw -->
+ <item>90</item> <!-- Yamper -->
+ <item>131</item> <!-- Boltund -->
+ <item>91</item> <!-- Rolycoly -->
+ <item>157</item> <!-- Carkol -->
+ <item>198</item> <!-- Coalossal -->
+ <item>116</item> <!-- Applin -->
+ <item>144</item> <!-- Flapple -->
+ <item>146</item> <!-- Appletun -->
+ <item>123</item> <!-- Silicobra -->
+ <item>207</item> <!-- Sandaconda -->
+ <item>163</item> <!-- Cramorant -->
+ <item>72</item> <!-- Arrokuda -->
+ <item>127</item> <!-- Barraskewda -->
+ <item>65</item> <!-- Toxel -->
+ <item>140</item> <!-- Toxtricity -->
+ <item>90</item> <!-- Sizzlipede -->
+ <item>158</item> <!-- Centiskorch -->
+ <item>103</item> <!-- Clobbopus -->
+ <item>162</item> <!-- Grapploct -->
+ <item>96</item> <!-- Sinistea -->
+ <item>189</item> <!-- Polteageist -->
+ <item>93</item> <!-- Hatenna -->
+ <item>133</item> <!-- Hattrem -->
+ <item>182</item> <!-- Hatterene -->
+ <item>69</item> <!-- Impidimp -->
+ <item>102</item> <!-- Morgrem -->
+ <item>139</item> <!-- Grimmsnarl -->
  <item>194</item> <!-- Obstagoon -->
  <item>162</item> <!-- Perrserker -->
+ <item>182</item> <!-- Cursola -->
  <item>176</item> <!-- Sirfetchd -->
  <item>179</item> <!-- Mr Rime -->
  <item>237</item> <!-- Runerigus -->
+ <item>97</item> <!-- Milcery -->
+ <item>203</item> <!-- Alcremie -->
+ <item>170</item> <!-- Falinks -->
+ <item>161</item> <!-- Pincurchin -->
+ <item>59</item> <!-- Snom -->
+ <item>155</item> <!-- Frosmoth -->
+ <item>182</item> <!-- Stonjourner -->
+ <item>195</item> <!-- Eiscue -->
+ <item>166</item> <!-- Indeedee -->
+ <item>121</item> <!-- Morpeko -->
+ <item>91</item> <!-- Cufant -->
+ <item>126</item> <!-- Copperajah -->
+ <item>165</item> <!-- Dracozolt -->
+ <item>166</item> <!-- Arctozolt -->
+ <item>185</item> <!-- Dracovish -->
+ <item>185</item> <!-- Arctovish -->
+ <item>185</item> <!-- Duraludon -->
+ <item>61</item> <!-- Dreepy -->
+ <item>105</item> <!-- Drakloak -->
+ <item>170</item> <!-- Dragapult -->
+ <item>236</item> <!-- Zacian -->
+ <item>236</item> <!-- Zamazenta -->
+ <item>192</item> <!-- Eternatus -->
+ <item>112</item> <!-- Kubfu -->
+ <item>177</item> <!-- Urshifu -->
+ <item>215</item> <!-- Zarude -->
+ <item>125</item> <!-- Regieleki -->
+ <item>101</item> <!-- Regidrago -->
+ <item>223</item> <!-- Glastrier -->
+ <item>146</item> <!-- Spectrier -->
+ <item>162</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="stamina">
  <item>128</item> <!-- Bulbasaur -->
@@ -2161,13 +2335,100 @@
  <item>198</item> <!-- Noivern -->
  <item>246</item> <!-- Xerneas -->
  <item>246</item> <!-- Yveltal -->
+ <item>137</item> <!-- Diancie -->
+ <item>173</item> <!-- Hoopa -->
+ <item>190</item> <!-- Volcanion -->
  <item>130</item> <!-- Meltan -->
  <item>264</item> <!-- Melmetal -->
+ <item>137</item> <!-- Grookey -->
+ <item>172</item> <!-- Thwackey -->
+ <item>225</item> <!-- Rillaboom -->
+ <item>137</item> <!-- Scorbunny -->
+ <item>163</item> <!-- Raboot -->
+ <item>190</item> <!-- Cinderace -->
+ <item>137</item> <!-- Sobble -->
+ <item>163</item> <!-- Drizzile -->
+ <item>172</item> <!-- Inteleon -->
+ <item>172</item> <!-- Skwovet -->
+ <item>260</item> <!-- Greedent -->
+ <item>116</item> <!-- Rookidee -->
+ <item>169</item> <!-- Corvisquire -->
+ <item>221</item> <!-- Corviknight -->
+ <item>93</item> <!-- Blipbug -->
+ <item>137</item> <!-- Dottler -->
+ <item>155</item> <!-- Orbeetle -->
+ <item>120</item> <!-- Nickit -->
+ <item>172</item> <!-- Thievul -->
+ <item>120</item> <!-- Gossifleur -->
+ <item>155</item> <!-- Eldegoss -->
+ <item>123</item> <!-- Wooloo -->
+ <item>176</item> <!-- Dubwool -->
+ <item>137</item> <!-- Chewtle -->
+ <item>207</item> <!-- Drednaw -->
+ <item>153</item> <!-- Yamper -->
+ <item>170</item> <!-- Boltund -->
+ <item>102</item> <!-- Rolycoly -->
+ <item>190</item> <!-- Carkol -->
+ <item>242</item> <!-- Coalossal -->
+ <item>120</item> <!-- Applin -->
+ <item>172</item> <!-- Flapple -->
+ <item>242</item> <!-- Appletun -->
+ <item>141</item> <!-- Silicobra -->
+ <item>176</item> <!-- Sandaconda -->
+ <item>172</item> <!-- Cramorant -->
+ <item>121</item> <!-- Arrokuda -->
+ <item>156</item> <!-- Barraskewda -->
+ <item>120</item> <!-- Toxel -->
+ <item>181</item> <!-- Toxtricity -->
+ <item>137</item> <!-- Sizzlipede -->
+ <item>225</item> <!-- Centiskorch -->
+ <item>137</item> <!-- Clobbopus -->
+ <item>190</item> <!-- Grapploct -->
+ <item>120</item> <!-- Sinistea -->
+ <item>155</item> <!-- Polteageist -->
+ <item>123</item> <!-- Hatenna -->
+ <item>149</item> <!-- Hattrem -->
+ <item>149</item> <!-- Hatterene -->
+ <item>128</item> <!-- Impidimp -->
+ <item>163</item> <!-- Morgrem -->
+ <item>216</item> <!-- Grimmsnarl -->
  <item>212</item> <!-- Obstagoon -->
  <item>172</item> <!-- Perrserker -->
+ <item>155</item> <!-- Cursola -->
  <item>158</item> <!-- Sirfetchd -->
  <item>190</item> <!-- Mr Rime -->
  <item>151</item> <!-- Runerigus -->
+ <item>128</item> <!-- Milcery -->
+ <item>163</item> <!-- Alcremie -->
+ <item>163</item> <!-- Falinks -->
+ <item>134</item> <!-- Pincurchin -->
+ <item>102</item> <!-- Snom -->
+ <item>172</item> <!-- Frosmoth -->
+ <item>225</item> <!-- Stonjourner -->
+ <item>181</item> <!-- Eiscue -->
+ <item>155</item> <!-- Indeedee -->
+ <item>151</item> <!-- Morpeko -->
+ <item>176</item> <!-- Cufant -->
+ <item>263</item> <!-- Copperajah -->
+ <item>207</item> <!-- Dracozolt -->
+ <item>207</item> <!-- Arctozolt -->
+ <item>207</item> <!-- Dracovish -->
+ <item>207</item> <!-- Arctovish -->
+ <item>172</item> <!-- Duraludon -->
+ <item>99</item> <!-- Dreepy -->
+ <item>169</item> <!-- Drakloak -->
+ <item>204</item> <!-- Dragapult -->
+ <item>192</item> <!-- Zacian -->
+ <item>192</item> <!-- Zamazenta -->
+ <item>268</item> <!-- Eternatus -->
+ <item>155</item> <!-- Kubfu -->
+ <item>225</item> <!-- Urshifu -->
+ <item>233</item> <!-- Zarude -->
+ <item>190</item> <!-- Regieleki -->
+ <item>400</item> <!-- Regidrago -->
+ <item>225</item> <!-- Glastrier -->
+ <item>205</item> <!-- Spectrier -->
+ <item>225</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="devolutionNumber">
  <item>-1</item> <!-- Bulbasaur -->
@@ -2884,13 +3145,100 @@
  <item>713</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Diancie -->
+ <item>-1</item> <!-- Hoopa -->
+ <item>-1</item> <!-- Volcanion -->
  <item>-1</item> <!-- Meltan -->
  <item>807</item> <!-- Melmetal -->
+ <item>-1</item> <!-- Grookey -->
+ <item>809</item> <!-- Thwackey -->
+ <item>810</item> <!-- Rillaboom -->
+ <item>-1</item> <!-- Scorbunny -->
+ <item>812</item> <!-- Raboot -->
+ <item>813</item> <!-- Cinderace -->
+ <item>-1</item> <!-- Sobble -->
+ <item>815</item> <!-- Drizzile -->
+ <item>816</item> <!-- Inteleon -->
+ <item>-1</item> <!-- Skwovet -->
+ <item>818</item> <!-- Greedent -->
+ <item>-1</item> <!-- Rookidee -->
+ <item>820</item> <!-- Corvisquire -->
+ <item>821</item> <!-- Corviknight -->
+ <item>-1</item> <!-- Blipbug -->
+ <item>823</item> <!-- Dottler -->
+ <item>824</item> <!-- Orbeetle -->
+ <item>-1</item> <!-- Nickit -->
+ <item>826</item> <!-- Thievul -->
+ <item>-1</item> <!-- Gossifleur -->
+ <item>828</item> <!-- Eldegoss -->
+ <item>-1</item> <!-- Wooloo -->
+ <item>830</item> <!-- Dubwool -->
+ <item>-1</item> <!-- Chewtle -->
+ <item>832</item> <!-- Drednaw -->
+ <item>-1</item> <!-- Yamper -->
+ <item>834</item> <!-- Boltund -->
+ <item>-1</item> <!-- Rolycoly -->
+ <item>835</item> <!-- Carkol -->
+ <item>836</item> <!-- Coalossal -->
+ <item>-1</item> <!-- Applin -->
+ <item>839</item> <!-- Flapple -->
+ <item>839</item> <!-- Appletun -->
+ <item>-1</item> <!-- Silicobra -->
+ <item>842</item> <!-- Sandaconda -->
+ <item>-1</item> <!-- Cramorant -->
+ <item>-1</item> <!-- Arrokuda -->
+ <item>845</item> <!-- Barraskewda -->
+ <item>-1</item> <!-- Toxel -->
+ <item>847</item> <!-- Toxtricity -->
+ <item>-1</item> <!-- Sizzlipede -->
+ <item>849</item> <!-- Centiskorch -->
+ <item>-1</item> <!-- Clobbopus -->
+ <item>851</item> <!-- Grapploct -->
+ <item>-1</item> <!-- Sinistea -->
+ <item>853</item> <!-- Polteageist -->
+ <item>-1</item> <!-- Hatenna -->
+ <item>855</item> <!-- Hattrem -->
+ <item>856</item> <!-- Hatterene -->
+ <item>-1</item> <!-- Impidimp -->
+ <item>858</item> <!-- Morgrem -->
+ <item>859</item> <!-- Grimmsnarl -->
  <item>262</item> <!-- Obstagoon -->
  <item>51</item> <!-- Perrserker -->
+ <item>221</item> <!-- Cursola -->
  <item>82</item> <!-- Sirfetchd -->
  <item>121</item> <!-- Mr Rime -->
  <item>561</item> <!-- Runerigus -->
+ <item>-1</item> <!-- Milcery -->
+ <item>867</item> <!-- Alcremie -->
+ <item>-1</item> <!-- Falinks -->
+ <item>-1</item> <!-- Pincurchin -->
+ <item>-1</item> <!-- Snom -->
+ <item>871</item> <!-- Frosmoth -->
+ <item>-1</item> <!-- Stonjourner -->
+ <item>-1</item> <!-- Eiscue -->
+ <item>-1</item> <!-- Indeedee -->
+ <item>-1</item> <!-- Morpeko -->
+ <item>-1</item> <!-- Cufant -->
+ <item>877</item> <!-- Copperajah -->
+ <item>-1</item> <!-- Dracozolt -->
+ <item>-1</item> <!-- Arctozolt -->
+ <item>-1</item> <!-- Dracovish -->
+ <item>-1</item> <!-- Arctovish -->
+ <item>-1</item> <!-- Duraludon -->
+ <item>-1</item> <!-- Dreepy -->
+ <item>884</item> <!-- Drakloak -->
+ <item>885</item> <!-- Dragapult -->
+ <item>-1</item> <!-- Zacian -->
+ <item>-1</item> <!-- Zamazenta -->
+ <item>-1</item> <!-- Eternatus -->
+ <item>-1</item> <!-- Kubfu -->
+ <item>890</item> <!-- Urshifu -->
+ <item>-1</item> <!-- Zarude -->
+ <item>-1</item> <!-- Regieleki -->
+ <item>-1</item> <!-- Regidrago -->
+ <item>-1</item> <!-- Glastrier -->
+ <item>-1</item> <!-- Spectrier -->
+ <item>-1</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="evolutionCandyCost">
  <item>25</item> <!-- Bulbasaur -->
@@ -3607,13 +3955,100 @@
  <item>-1</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Diancie -->
+ <item>-1</item> <!-- Hoopa -->
+ <item>-1</item> <!-- Volcanion -->
  <item>400</item> <!-- Meltan -->
  <item>-1</item> <!-- Melmetal -->
+ <item>25</item> <!-- Grookey -->
+ <item>100</item> <!-- Thwackey -->
+ <item>-1</item> <!-- Rillaboom -->
+ <item>25</item> <!-- Scorbunny -->
+ <item>100</item> <!-- Raboot -->
+ <item>-1</item> <!-- Cinderace -->
+ <item>25</item> <!-- Sobble -->
+ <item>100</item> <!-- Drizzile -->
+ <item>-1</item> <!-- Inteleon -->
+ <item>50</item> <!-- Skwovet -->
+ <item>-1</item> <!-- Greedent -->
+ <item>25</item> <!-- Rookidee -->
+ <item>100</item> <!-- Corvisquire -->
+ <item>-1</item> <!-- Corviknight -->
+ <item>25</item> <!-- Blipbug -->
+ <item>100</item> <!-- Dottler -->
+ <item>-1</item> <!-- Orbeetle -->
+ <item>50</item> <!-- Nickit -->
+ <item>-1</item> <!-- Thievul -->
+ <item>50</item> <!-- Gossifleur -->
+ <item>-1</item> <!-- Eldegoss -->
+ <item>50</item> <!-- Wooloo -->
+ <item>-1</item> <!-- Dubwool -->
+ <item>50</item> <!-- Chewtle -->
+ <item>-1</item> <!-- Drednaw -->
+ <item>50</item> <!-- Yamper -->
+ <item>-1</item> <!-- Boltund -->
+ <item>25</item> <!-- Rolycoly -->
+ <item>100</item> <!-- Carkol -->
+ <item>-1</item> <!-- Coalossal -->
+ <item>400</item> <!-- Applin -->
+ <item>-1</item> <!-- Flapple -->
+ <item>-1</item> <!-- Appletun -->
+ <item>50</item> <!-- Silicobra -->
+ <item>-1</item> <!-- Sandaconda -->
+ <item>-1</item> <!-- Cramorant -->
+ <item>50</item> <!-- Arrokuda -->
+ <item>-1</item> <!-- Barraskewda -->
+ <item>50</item> <!-- Toxel -->
+ <item>-1</item> <!-- Toxtricity -->
+ <item>50</item> <!-- Sizzlipede -->
+ <item>-1</item> <!-- Centiskorch -->
+ <item>50</item> <!-- Clobbopus -->
+ <item>-1</item> <!-- Grapploct -->
+ <item>50</item> <!-- Sinistea -->
+ <item>-1</item> <!-- Polteageist -->
+ <item>25</item> <!-- Hatenna -->
+ <item>100</item> <!-- Hattrem -->
+ <item>-1</item> <!-- Hatterene -->
+ <item>25</item> <!-- Impidimp -->
+ <item>100</item> <!-- Morgrem -->
+ <item>-1</item> <!-- Grimmsnarl -->
  <item>-1</item> <!-- Obstagoon -->
  <item>-1</item> <!-- Perrserker -->
+ <item>-1</item> <!-- Cursola -->
  <item>-1</item> <!-- Sirfetchd -->
  <item>-1</item> <!-- Mr Rime -->
  <item>-1</item> <!-- Runerigus -->
+ <item>50</item> <!-- Milcery -->
+ <item>-1</item> <!-- Alcremie -->
+ <item>-1</item> <!-- Falinks -->
+ <item>-1</item> <!-- Pincurchin -->
+ <item>50</item> <!-- Snom -->
+ <item>-1</item> <!-- Frosmoth -->
+ <item>-1</item> <!-- Stonjourner -->
+ <item>-1</item> <!-- Eiscue -->
+ <item>-1</item> <!-- Indeedee -->
+ <item>-1</item> <!-- Morpeko -->
+ <item>50</item> <!-- Cufant -->
+ <item>-1</item> <!-- Copperajah -->
+ <item>-1</item> <!-- Dracozolt -->
+ <item>-1</item> <!-- Arctozolt -->
+ <item>-1</item> <!-- Dracovish -->
+ <item>-1</item> <!-- Arctovish -->
+ <item>-1</item> <!-- Duraludon -->
+ <item>25</item> <!-- Dreepy -->
+ <item>100</item> <!-- Drakloak -->
+ <item>-1</item> <!-- Dragapult -->
+ <item>-1</item> <!-- Zacian -->
+ <item>-1</item> <!-- Zamazenta -->
+ <item>-1</item> <!-- Eternatus -->
+ <item>400</item> <!-- Kubfu -->
+ <item>-1</item> <!-- Urshifu -->
+ <item>-1</item> <!-- Zarude -->
+ <item>-1</item> <!-- Regieleki -->
+ <item>-1</item> <!-- Regidrago -->
+ <item>-1</item> <!-- Glastrier -->
+ <item>-1</item> <!-- Spectrier -->
+ <item>-1</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="candyNames">
  <item>0</item> <!-- Bulbasaur -->
@@ -4330,13 +4765,100 @@
  <item>713</item> <!-- Noivern -->
  <item>715</item> <!-- Xerneas -->
  <item>716</item> <!-- Yveltal -->
+ <item>718</item> <!-- Diancie -->
+ <item>719</item> <!-- Hoopa -->
+ <item>720</item> <!-- Volcanion -->
  <item>807</item> <!-- Meltan -->
  <item>807</item> <!-- Melmetal -->
+ <item>809</item> <!-- Grookey -->
+ <item>809</item> <!-- Thwackey -->
+ <item>809</item> <!-- Rillaboom -->
+ <item>812</item> <!-- Scorbunny -->
+ <item>812</item> <!-- Raboot -->
+ <item>812</item> <!-- Cinderace -->
+ <item>815</item> <!-- Sobble -->
+ <item>815</item> <!-- Drizzile -->
+ <item>815</item> <!-- Inteleon -->
+ <item>818</item> <!-- Skwovet -->
+ <item>818</item> <!-- Greedent -->
+ <item>820</item> <!-- Rookidee -->
+ <item>820</item> <!-- Corvisquire -->
+ <item>820</item> <!-- Corviknight -->
+ <item>823</item> <!-- Blipbug -->
+ <item>823</item> <!-- Dottler -->
+ <item>823</item> <!-- Orbeetle -->
+ <item>826</item> <!-- Nickit -->
+ <item>826</item> <!-- Thievul -->
+ <item>828</item> <!-- Gossifleur -->
+ <item>828</item> <!-- Eldegoss -->
+ <item>830</item> <!-- Wooloo -->
+ <item>830</item> <!-- Dubwool -->
+ <item>832</item> <!-- Chewtle -->
+ <item>832</item> <!-- Drednaw -->
+ <item>834</item> <!-- Yamper -->
+ <item>834</item> <!-- Boltund -->
+ <item>836</item> <!-- Rolycoly -->
+ <item>836</item> <!-- Carkol -->
+ <item>836</item> <!-- Coalossal -->
+ <item>839</item> <!-- Applin -->
+ <item>839</item> <!-- Flapple -->
+ <item>839</item> <!-- Appletun -->
+ <item>842</item> <!-- Silicobra -->
+ <item>842</item> <!-- Sandaconda -->
+ <item>844</item> <!-- Cramorant -->
+ <item>845</item> <!-- Arrokuda -->
+ <item>845</item> <!-- Barraskewda -->
+ <item>847</item> <!-- Toxel -->
+ <item>847</item> <!-- Toxtricity -->
+ <item>849</item> <!-- Sizzlipede -->
+ <item>849</item> <!-- Centiskorch -->
+ <item>851</item> <!-- Clobbopus -->
+ <item>851</item> <!-- Grapploct -->
+ <item>853</item> <!-- Sinistea -->
+ <item>853</item> <!-- Polteageist -->
+ <item>855</item> <!-- Hatenna -->
+ <item>855</item> <!-- Hattrem -->
+ <item>855</item> <!-- Hatterene -->
+ <item>858</item> <!-- Impidimp -->
+ <item>858</item> <!-- Morgrem -->
+ <item>858</item> <!-- Grimmsnarl -->
  <item>262</item> <!-- Obstagoon -->
  <item>51</item> <!-- Perrserker -->
+ <item>221</item> <!-- Cursola -->
  <item>82</item> <!-- Sirfetchd -->
  <item>121</item> <!-- Mr Rime -->
  <item>561</item> <!-- Runerigus -->
+ <item>867</item> <!-- Milcery -->
+ <item>867</item> <!-- Alcremie -->
+ <item>869</item> <!-- Falinks -->
+ <item>870</item> <!-- Pincurchin -->
+ <item>871</item> <!-- Snom -->
+ <item>871</item> <!-- Frosmoth -->
+ <item>873</item> <!-- Stonjourner -->
+ <item>874</item> <!-- Eiscue -->
+ <item>875</item> <!-- Indeedee -->
+ <item>876</item> <!-- Morpeko -->
+ <item>877</item> <!-- Cufant -->
+ <item>877</item> <!-- Copperajah -->
+ <item>879</item> <!-- Dracozolt -->
+ <item>880</item> <!-- Arctozolt -->
+ <item>881</item> <!-- Dracovish -->
+ <item>882</item> <!-- Arctovish -->
+ <item>883</item> <!-- Duraludon -->
+ <item>884</item> <!-- Dreepy -->
+ <item>884</item> <!-- Drakloak -->
+ <item>884</item> <!-- Dragapult -->
+ <item>887</item> <!-- Zacian -->
+ <item>888</item> <!-- Zamazenta -->
+ <item>889</item> <!-- Eternatus -->
+ <item>890</item> <!-- Kubfu -->
+ <item>890</item> <!-- Urshifu -->
+ <item>892</item> <!-- Zarude -->
+ <item>893</item> <!-- Regieleki -->
+ <item>894</item> <!-- Regidrago -->
+ <item>895</item> <!-- Glastrier -->
+ <item>896</item> <!-- Spectrier -->
+ <item>897</item> <!-- Calyrex -->
 </integer-array>
 <integer-array name="formsCountIndex">
  <item>-1</item> <!-- Bulbasaur -->
@@ -4537,9 +5059,9 @@
  <item>-1</item> <!-- Espeon -->
  <item>-1</item> <!-- Umbreon -->
  <item>-1</item> <!-- Murkrow -->
- <item>-1</item> <!-- Slowking -->
+ <item>28</item> <!-- Slowking -->
  <item>-1</item> <!-- Misdreavus -->
- <item>28</item> <!-- Unown -->
+ <item>29</item> <!-- Unown -->
  <item>-1</item> <!-- Wobbuffet -->
  <item>-1</item> <!-- Girafarig -->
  <item>-1</item> <!-- Pineco -->
@@ -4563,7 +5085,7 @@
  <item>-1</item> <!-- Corsola -->
  <item>-1</item> <!-- Remoraid -->
  <item>-1</item> <!-- Octillery -->
- <item>29</item> <!-- Delibird -->
+ <item>30</item> <!-- Delibird -->
  <item>-1</item> <!-- Mantine -->
  <item>-1</item> <!-- Skarmory -->
  <item>-1</item> <!-- Houndour -->
@@ -4601,8 +5123,8 @@
  <item>-1</item> <!-- Swampert -->
  <item>-1</item> <!-- Poochyena -->
  <item>-1</item> <!-- Mightyena -->
- <item>30</item> <!-- Zigzagoon -->
- <item>31</item> <!-- Linoone -->
+ <item>31</item> <!-- Zigzagoon -->
+ <item>32</item> <!-- Linoone -->
  <item>-1</item> <!-- Wurmple -->
  <item>-1</item> <!-- Silcoon -->
  <item>-1</item> <!-- Beautifly -->
@@ -4640,7 +5162,7 @@
  <item>-1</item> <!-- Nosepass -->
  <item>-1</item> <!-- Skitty -->
  <item>-1</item> <!-- Delcatty -->
- <item>32</item> <!-- Sableye -->
+ <item>33</item> <!-- Sableye -->
  <item>-1</item> <!-- Mawile -->
  <item>-1</item> <!-- Aron -->
  <item>-1</item> <!-- Lairon -->
@@ -4665,7 +5187,7 @@
  <item>-1</item> <!-- Torkoal -->
  <item>-1</item> <!-- Spoink -->
  <item>-1</item> <!-- Grumpig -->
- <item>33</item> <!-- Spinda -->
+ <item>34</item> <!-- Spinda -->
  <item>-1</item> <!-- Trapinch -->
  <item>-1</item> <!-- Vibrava -->
  <item>-1</item> <!-- Flygon -->
@@ -4689,7 +5211,7 @@
  <item>-1</item> <!-- Armaldo -->
  <item>-1</item> <!-- Feebas -->
  <item>-1</item> <!-- Milotic -->
- <item>34</item> <!-- Castform -->
+ <item>35</item> <!-- Castform -->
  <item>-1</item> <!-- Kecleon -->
  <item>-1</item> <!-- Shuppet -->
  <item>-1</item> <!-- Banette -->
@@ -4724,7 +5246,7 @@
  <item>-1</item> <!-- Groudon -->
  <item>-1</item> <!-- Rayquaza -->
  <item>-1</item> <!-- Jirachi -->
- <item>35</item> <!-- Deoxys -->
+ <item>36</item> <!-- Deoxys -->
  <item>-1</item> <!-- Turtwig -->
  <item>-1</item> <!-- Grotle -->
  <item>-1</item> <!-- Torterra -->
@@ -4750,8 +5272,8 @@
  <item>-1</item> <!-- Rampardos -->
  <item>-1</item> <!-- Shieldon -->
  <item>-1</item> <!-- Bastiodon -->
- <item>36</item> <!-- Burmy -->
- <item>37</item> <!-- Wormadam -->
+ <item>37</item> <!-- Burmy -->
+ <item>38</item> <!-- Wormadam -->
  <item>-1</item> <!-- Mothim -->
  <item>-1</item> <!-- Combee -->
  <item>-1</item> <!-- Vespiquen -->
@@ -4759,9 +5281,9 @@
  <item>-1</item> <!-- Buizel -->
  <item>-1</item> <!-- Floatzel -->
  <item>-1</item> <!-- Cherubi -->
- <item>38</item> <!-- Cherrim -->
- <item>39</item> <!-- Shellos -->
- <item>40</item> <!-- Gastrodon -->
+ <item>39</item> <!-- Cherrim -->
+ <item>40</item> <!-- Shellos -->
+ <item>41</item> <!-- Gastrodon -->
  <item>-1</item> <!-- Ambipom -->
  <item>-1</item> <!-- Drifloon -->
  <item>-1</item> <!-- Drifblim -->
@@ -4817,7 +5339,7 @@
  <item>-1</item> <!-- Probopass -->
  <item>-1</item> <!-- Dusknoir -->
  <item>-1</item> <!-- Froslass -->
- <item>41</item> <!-- Rotom -->
+ <item>42</item> <!-- Rotom -->
  <item>-1</item> <!-- Uxie -->
  <item>-1</item> <!-- Mesprit -->
  <item>-1</item> <!-- Azelf -->
@@ -4825,13 +5347,13 @@
  <item>-1</item> <!-- Palkia -->
  <item>-1</item> <!-- Heatran -->
  <item>-1</item> <!-- Regigigas -->
- <item>42</item> <!-- Giratina -->
+ <item>43</item> <!-- Giratina -->
  <item>-1</item> <!-- Cresselia -->
  <item>-1</item> <!-- Phione -->
  <item>-1</item> <!-- Manaphy -->
  <item>-1</item> <!-- Darkrai -->
- <item>43</item> <!-- Shaymin -->
- <item>44</item> <!-- Arceus -->
+ <item>44</item> <!-- Shaymin -->
+ <item>45</item> <!-- Arceus -->
  <item>-1</item> <!-- Victini -->
  <item>-1</item> <!-- Snivy -->
  <item>-1</item> <!-- Servine -->
@@ -4888,19 +5410,19 @@
  <item>-1</item> <!-- Whimsicott -->
  <item>-1</item> <!-- Petilil -->
  <item>-1</item> <!-- Lilligant -->
- <item>45</item> <!-- Basculin -->
+ <item>46</item> <!-- Basculin -->
  <item>-1</item> <!-- Sandile -->
  <item>-1</item> <!-- Krokorok -->
  <item>-1</item> <!-- Krookodile -->
- <item>46</item> <!-- Darumaka -->
- <item>47</item> <!-- Darmanitan -->
+ <item>47</item> <!-- Darumaka -->
+ <item>48</item> <!-- Darmanitan -->
  <item>-1</item> <!-- Maractus -->
  <item>-1</item> <!-- Dwebble -->
  <item>-1</item> <!-- Crustle -->
  <item>-1</item> <!-- Scraggy -->
  <item>-1</item> <!-- Scrafty -->
  <item>-1</item> <!-- Sigilyph -->
- <item>48</item> <!-- Yamask -->
+ <item>49</item> <!-- Yamask -->
  <item>-1</item> <!-- Cofagrigus -->
  <item>-1</item> <!-- Tirtouga -->
  <item>-1</item> <!-- Carracosta -->
@@ -4923,15 +5445,15 @@
  <item>-1</item> <!-- Vanillite -->
  <item>-1</item> <!-- Vanillish -->
  <item>-1</item> <!-- Vanilluxe -->
- <item>49</item> <!-- Deerling -->
- <item>50</item> <!-- Sawsbuck -->
+ <item>50</item> <!-- Deerling -->
+ <item>51</item> <!-- Sawsbuck -->
  <item>-1</item> <!-- Emolga -->
  <item>-1</item> <!-- Karrablast -->
  <item>-1</item> <!-- Escavalier -->
  <item>-1</item> <!-- Foongus -->
  <item>-1</item> <!-- Amoonguss -->
- <item>51</item> <!-- Frillish -->
- <item>52</item> <!-- Jellicent -->
+ <item>52</item> <!-- Frillish -->
+ <item>53</item> <!-- Jellicent -->
  <item>-1</item> <!-- Alomomola -->
  <item>-1</item> <!-- Joltik -->
  <item>-1</item> <!-- Galvantula -->
@@ -4951,12 +5473,12 @@
  <item>-1</item> <!-- Axew -->
  <item>-1</item> <!-- Fraxure -->
  <item>-1</item> <!-- Haxorus -->
- <item>53</item> <!-- Cubchoo -->
+ <item>54</item> <!-- Cubchoo -->
  <item>-1</item> <!-- Beartic -->
  <item>-1</item> <!-- Cryogonal -->
  <item>-1</item> <!-- Shelmet -->
  <item>-1</item> <!-- Accelgor -->
- <item>54</item> <!-- Stunfisk -->
+ <item>55</item> <!-- Stunfisk -->
  <item>-1</item> <!-- Mienfoo -->
  <item>-1</item> <!-- Mienshao -->
  <item>-1</item> <!-- Druddigon -->
@@ -4979,15 +5501,15 @@
  <item>-1</item> <!-- Cobalion -->
  <item>-1</item> <!-- Terrakion -->
  <item>-1</item> <!-- Virizion -->
- <item>55</item> <!-- Tornadus -->
- <item>56</item> <!-- Thundurus -->
+ <item>56</item> <!-- Tornadus -->
+ <item>57</item> <!-- Thundurus -->
  <item>-1</item> <!-- Reshiram -->
  <item>-1</item> <!-- Zekrom -->
- <item>57</item> <!-- Landorus -->
- <item>58</item> <!-- Kyurem -->
- <item>59</item> <!-- Keldeo -->
- <item>60</item> <!-- Meloetta -->
- <item>61</item> <!-- Genesect -->
+ <item>58</item> <!-- Landorus -->
+ <item>59</item> <!-- Kyurem -->
+ <item>60</item> <!-- Keldeo -->
+ <item>61</item> <!-- Meloetta -->
+ <item>62</item> <!-- Genesect -->
  <item>-1</item> <!-- Chespin -->
  <item>-1</item> <!-- Quilladin -->
  <item>-1</item> <!-- Chesnaught -->
@@ -5006,7 +5528,7 @@
  <item>-1</item> <!-- Spewpa -->
  <item>-1</item> <!-- Vivillon -->
  <item>-1</item> <!-- Litleo -->
- <item>62</item> <!-- Pyroar -->
+ <item>63</item> <!-- Pyroar -->
  <item>-1</item> <!-- Flabebe -->
  <item>-1</item> <!-- Floette -->
  <item>-1</item> <!-- Florges -->
@@ -5014,9 +5536,9 @@
  <item>-1</item> <!-- Gogoat -->
  <item>-1</item> <!-- Pancham -->
  <item>-1</item> <!-- Pangoro -->
- <item>63</item> <!-- Furfrou -->
+ <item>64</item> <!-- Furfrou -->
  <item>-1</item> <!-- Espurr -->
- <item>64</item> <!-- Meowstic -->
+ <item>65</item> <!-- Meowstic -->
  <item>-1</item> <!-- Spritzee -->
  <item>-1</item> <!-- Aromatisse -->
  <item>-1</item> <!-- Swirlix -->
@@ -5053,12 +5575,99 @@
  <item>-1</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Diancie -->
+ <item>66</item> <!-- Hoopa -->
+ <item>-1</item> <!-- Volcanion -->
  <item>-1</item> <!-- Meltan -->
  <item>-1</item> <!-- Melmetal -->
+ <item>-1</item> <!-- Grookey -->
+ <item>-1</item> <!-- Thwackey -->
+ <item>-1</item> <!-- Rillaboom -->
+ <item>-1</item> <!-- Scorbunny -->
+ <item>-1</item> <!-- Raboot -->
+ <item>-1</item> <!-- Cinderace -->
+ <item>-1</item> <!-- Sobble -->
+ <item>-1</item> <!-- Drizzile -->
+ <item>-1</item> <!-- Inteleon -->
+ <item>-1</item> <!-- Skwovet -->
+ <item>-1</item> <!-- Greedent -->
+ <item>-1</item> <!-- Rookidee -->
+ <item>-1</item> <!-- Corvisquire -->
+ <item>-1</item> <!-- Corviknight -->
+ <item>-1</item> <!-- Blipbug -->
+ <item>-1</item> <!-- Dottler -->
+ <item>-1</item> <!-- Orbeetle -->
+ <item>-1</item> <!-- Nickit -->
+ <item>-1</item> <!-- Thievul -->
+ <item>-1</item> <!-- Gossifleur -->
+ <item>-1</item> <!-- Eldegoss -->
+ <item>-1</item> <!-- Wooloo -->
+ <item>-1</item> <!-- Dubwool -->
+ <item>-1</item> <!-- Chewtle -->
+ <item>-1</item> <!-- Drednaw -->
+ <item>-1</item> <!-- Yamper -->
+ <item>-1</item> <!-- Boltund -->
+ <item>-1</item> <!-- Rolycoly -->
+ <item>-1</item> <!-- Carkol -->
+ <item>-1</item> <!-- Coalossal -->
+ <item>-1</item> <!-- Applin -->
+ <item>-1</item> <!-- Flapple -->
+ <item>-1</item> <!-- Appletun -->
+ <item>-1</item> <!-- Silicobra -->
+ <item>-1</item> <!-- Sandaconda -->
+ <item>-1</item> <!-- Cramorant -->
+ <item>-1</item> <!-- Arrokuda -->
+ <item>-1</item> <!-- Barraskewda -->
+ <item>-1</item> <!-- Toxel -->
+ <item>67</item> <!-- Toxtricity -->
+ <item>-1</item> <!-- Sizzlipede -->
+ <item>-1</item> <!-- Centiskorch -->
+ <item>-1</item> <!-- Clobbopus -->
+ <item>-1</item> <!-- Grapploct -->
+ <item>68</item> <!-- Sinistea -->
+ <item>69</item> <!-- Polteageist -->
+ <item>-1</item> <!-- Hatenna -->
+ <item>-1</item> <!-- Hattrem -->
+ <item>-1</item> <!-- Hatterene -->
+ <item>-1</item> <!-- Impidimp -->
+ <item>-1</item> <!-- Morgrem -->
+ <item>-1</item> <!-- Grimmsnarl -->
  <item>-1</item> <!-- Obstagoon -->
  <item>-1</item> <!-- Perrserker -->
+ <item>-1</item> <!-- Cursola -->
  <item>-1</item> <!-- Sirfetchd -->
  <item>-1</item> <!-- Mr Rime -->
  <item>-1</item> <!-- Runerigus -->
+ <item>-1</item> <!-- Milcery -->
+ <item>-1</item> <!-- Alcremie -->
+ <item>-1</item> <!-- Falinks -->
+ <item>-1</item> <!-- Pincurchin -->
+ <item>-1</item> <!-- Snom -->
+ <item>-1</item> <!-- Frosmoth -->
+ <item>-1</item> <!-- Stonjourner -->
+ <item>70</item> <!-- Eiscue -->
+ <item>71</item> <!-- Indeedee -->
+ <item>72</item> <!-- Morpeko -->
+ <item>-1</item> <!-- Cufant -->
+ <item>-1</item> <!-- Copperajah -->
+ <item>-1</item> <!-- Dracozolt -->
+ <item>-1</item> <!-- Arctozolt -->
+ <item>-1</item> <!-- Dracovish -->
+ <item>-1</item> <!-- Arctovish -->
+ <item>-1</item> <!-- Duraludon -->
+ <item>-1</item> <!-- Dreepy -->
+ <item>-1</item> <!-- Drakloak -->
+ <item>-1</item> <!-- Dragapult -->
+ <item>73</item> <!-- Zacian -->
+ <item>74</item> <!-- Zamazenta -->
+ <item>75</item> <!-- Eternatus -->
+ <item>-1</item> <!-- Kubfu -->
+ <item>76</item> <!-- Urshifu -->
+ <item>-1</item> <!-- Zarude -->
+ <item>-1</item> <!-- Regieleki -->
+ <item>-1</item> <!-- Regidrago -->
+ <item>-1</item> <!-- Glastrier -->
+ <item>-1</item> <!-- Spectrier -->
+ <item>77</item> <!-- Calyrex -->
 </integer-array>
 </resources>

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -679,6 +679,9 @@
  <item>164</item> <!-- Furfrou -->
  <item>120</item> <!-- Espurr -->
  <item>166</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>110</item> <!-- Spritzee -->
  <item>173</item> <!-- Aromatisse -->
  <item>109</item> <!-- Swirlix -->
@@ -715,9 +718,96 @@
  <item>205</item> <!-- Noivern -->
  <item>250</item> <!-- Xerneas -->
  <item>250</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>190</item> <!-- Diancie -->
  <item>261</item> <!-- Hoopa -->
  <item>252</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>118</item> <!-- Meltan -->
  <item>226</item> <!-- Melmetal -->
  <item>122</item> <!-- Grookey -->
@@ -1489,6 +1579,9 @@
  <item>167</item> <!-- Furfrou -->
  <item>114</item> <!-- Espurr -->
  <item>167</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>113</item> <!-- Spritzee -->
  <item>150</item> <!-- Aromatisse -->
  <item>119</item> <!-- Swirlix -->
@@ -1525,9 +1618,96 @@
  <item>175</item> <!-- Noivern -->
  <item>185</item> <!-- Xerneas -->
  <item>185</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>285</item> <!-- Diancie -->
  <item>187</item> <!-- Hoopa -->
  <item>216</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>99</item> <!-- Meltan -->
  <item>190</item> <!-- Melmetal -->
  <item>91</item> <!-- Grookey -->
@@ -2299,6 +2479,9 @@
  <item>181</item> <!-- Furfrou -->
  <item>158</item> <!-- Espurr -->
  <item>179</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>186</item> <!-- Spritzee -->
  <item>226</item> <!-- Aromatisse -->
  <item>158</item> <!-- Swirlix -->
@@ -2335,9 +2518,96 @@
  <item>198</item> <!-- Noivern -->
  <item>246</item> <!-- Xerneas -->
  <item>246</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>137</item> <!-- Diancie -->
  <item>173</item> <!-- Hoopa -->
  <item>190</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>130</item> <!-- Meltan -->
  <item>264</item> <!-- Melmetal -->
  <item>137</item> <!-- Grookey -->
@@ -3109,6 +3379,9 @@
  <item>-1</item> <!-- Furfrou -->
  <item>-1</item> <!-- Espurr -->
  <item>676</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Spritzee -->
  <item>681</item> <!-- Aromatisse -->
  <item>-1</item> <!-- Swirlix -->
@@ -3145,9 +3418,96 @@
  <item>713</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Diancie -->
  <item>-1</item> <!-- Hoopa -->
  <item>-1</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Meltan -->
  <item>807</item> <!-- Melmetal -->
  <item>-1</item> <!-- Grookey -->
@@ -3919,6 +4279,9 @@
  <item>-1</item> <!-- Furfrou -->
  <item>50</item> <!-- Espurr -->
  <item>-1</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>50</item> <!-- Spritzee -->
  <item>-1</item> <!-- Aromatisse -->
  <item>50</item> <!-- Swirlix -->
@@ -3955,9 +4318,96 @@
  <item>-1</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Diancie -->
  <item>-1</item> <!-- Hoopa -->
  <item>-1</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>400</item> <!-- Meltan -->
  <item>-1</item> <!-- Melmetal -->
  <item>25</item> <!-- Grookey -->
@@ -4729,6 +5179,9 @@
  <item>675</item> <!-- Furfrou -->
  <item>676</item> <!-- Espurr -->
  <item>676</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>681</item> <!-- Spritzee -->
  <item>681</item> <!-- Aromatisse -->
  <item>683</item> <!-- Swirlix -->
@@ -4765,9 +5218,96 @@
  <item>713</item> <!-- Noivern -->
  <item>715</item> <!-- Xerneas -->
  <item>716</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>718</item> <!-- Diancie -->
  <item>719</item> <!-- Hoopa -->
  <item>720</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>807</item> <!-- Meltan -->
  <item>807</item> <!-- Melmetal -->
  <item>809</item> <!-- Grookey -->
@@ -5539,6 +6079,9 @@
  <item>64</item> <!-- Furfrou -->
  <item>-1</item> <!-- Espurr -->
  <item>65</item> <!-- Meowstic -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Spritzee -->
  <item>-1</item> <!-- Aromatisse -->
  <item>-1</item> <!-- Swirlix -->
@@ -5575,9 +6118,96 @@
  <item>-1</item> <!-- Noivern -->
  <item>-1</item> <!-- Xerneas -->
  <item>-1</item> <!-- Yveltal -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Diancie -->
  <item>66</item> <!-- Hoopa -->
  <item>-1</item> <!-- Volcanion -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
+ <item>-1</item> <!-- Placeholder -->
  <item>-1</item> <!-- Meltan -->
  <item>-1</item> <!-- Melmetal -->
  <item>-1</item> <!-- Grookey -->

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -715,12 +715,99 @@
         <item>Noivern</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Diancie</item>
+        <item>Hoopa</item>
+        <item>Volcanion</item>
         <item>Meltan</item>
         <item>Melmetal</item>
+        <item>Grookey</item>
+        <item>Thwackey</item>
+        <item>Rillaboom</item>
+        <item>Scorbunny</item>
+        <item>Raboot</item>
+        <item>Cinderace</item>
+        <item>Sobble</item>
+        <item>Drizzile</item>
+        <item>Inteleon</item>
+        <item>Skwovet</item>
+        <item>Greedent</item>
+        <item>Rookidee</item>
+        <item>Corvisquire</item>
+        <item>Corviknight</item>
+        <item>Blipbug</item>
+        <item>Dottler</item>
+        <item>Orbeetle</item>
+        <item>Nickit</item>
+        <item>Thievul</item>
+        <item>Gossifleur</item>
+        <item>Eldegoss</item>
+        <item>Wooloo</item>
+        <item>Dubwool</item>
+        <item>Chewtle</item>
+        <item>Drednaw</item>
+        <item>Yamper</item>
+        <item>Boltund</item>
+        <item>Rolycoly</item>
+        <item>Carkol</item>
+        <item>Coalossal</item>
+        <item>Applin</item>
+        <item>Flapple</item>
+        <item>Appletun</item>
+        <item>Silicobra</item>
+        <item>Sandaconda</item>
+        <item>Cramorant</item>
+        <item>Arrokuda</item>
+        <item>Barraskewda</item>
+        <item>Toxel</item>
+        <item>Toxtricity</item>
+        <item>Sizzlipede</item>
+        <item>Centiskorch</item>
+        <item>Clobbopus</item>
+        <item>Grapploct</item>
+        <item>Sinistea</item>
+        <item>Polteageist</item>
+        <item>Hatenna</item>
+        <item>Hattrem</item>
+        <item>Hatterene</item>
+        <item>Impidimp</item>
+        <item>Morgrem</item>
+        <item>Grimmsnarl</item>
         <item>Obstagoon</item>
         <item>Perrserker</item>
+        <item>Cursola</item>
         <item>Sirfetch’d</item>
         <item>Mr. Rime</item>
         <item>Runerigus</item>
+        <item>Milcery</item>
+        <item>Alcremie</item>
+        <item>Falinks</item>
+        <item>Pincurchin</item>
+        <item>Snom</item>
+        <item>Frosmoth</item>
+        <item>Stonjourner</item>
+        <item>Eiscue</item>
+        <item>Indeedee</item>
+        <item>Morpeko</item>
+        <item>Cufant</item>
+        <item>Copperajah</item>
+        <item>Dracozolt</item>
+        <item>Arctozolt</item>
+        <item>Dracovish</item>
+        <item>Arctovish</item>
+        <item>Duraludon</item>
+        <item>Dreepy</item>
+        <item>Drakloak</item>
+        <item>Dragapult</item>
+        <item>Zacian</item>
+        <item>Zamazenta</item>
+        <item>Eternatus</item>
+        <item>Kubfu</item>
+        <item>Urshifu</item>
+        <item>Zarude</item>
+        <item>Regieleki</item>
+        <item>Regidrago</item>
+        <item>Glastrier</item>
+        <item>Spectrier</item>
+        <item>Calyrex</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/pokemons.xml
+++ b/app/src/main/res/values/pokemons.xml
@@ -679,6 +679,9 @@
         <item>Furfrou</item>
         <item>Espurr</item>
         <item>Meowstic</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Spritzee</item>
         <item>Aromatisse</item>
         <item>Swirlix</item>
@@ -715,9 +718,96 @@
         <item>Noivern</item>
         <item>Xerneas</item>
         <item>Yveltal</item>
+        <item>Placeholder</item>
         <item>Diancie</item>
         <item>Hoopa</item>
         <item>Volcanion</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
+        <item>Placeholder</item>
         <item>Meltan</item>
         <item>Melmetal</item>
         <item>Grookey</item>

--- a/devMethods/src/main/java/com/kamron/pogoiv/devMethods/gameMasterParser/ApplicationDatabaseUpdater.java
+++ b/devMethods/src/main/java/com/kamron/pogoiv/devMethods/gameMasterParser/ApplicationDatabaseUpdater.java
@@ -225,6 +225,15 @@ public class ApplicationDatabaseUpdater {
                     }
                 }
             }
+            else {
+                for (int j = 0; j < languages.size(); j++) {
+                    String language = languages.get(j);
+                    if (language != null) {
+                        translations.get(language).add("Placeholder");
+                    }
+                }
+
+            }
         }
 
         for (String language : languages) {
@@ -293,11 +302,15 @@ public class ApplicationDatabaseUpdater {
         formsCountIndexBuilder.append("<integer-array name=\"formsCountIndex\">\n");
 
         int maxPokedex = Collections.max(formsByPokedex.keySet());
+        boolean numberHandled;
         for (int i = 1; i <= maxPokedex; i++) {
+            numberHandled = false;
             if (formsByPokedex.containsKey(i)) {
                 FormSettings form = formsByPokedex.get(i);
                 HashMap<String, PokemonSettings> formHash = pokemonFormsByName.get(form.getName());
                 if (formHash != null) {
+                    numberHandled = true;
+
                     PokemonSettings poke = formHash.get(null);
                     String pokemonName = titleCase(form.getName());
                     Stats stats = poke.getStats();
@@ -333,6 +346,19 @@ public class ApplicationDatabaseUpdater {
                     formsCountIndexFormatter.format(integerArrayFormat, pokemonWithMultipleForms.indexOf(form));
                     formsCountIndexFormatter.format(commentFormat, pokemonName);
                 }  // Some pokemon have form data in the game, but not pokemon data??
+            }
+            if (numberHandled == false) {
+                attackFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+                defenseFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+                staminaFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+
+                devolutionNumberFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+
+                evolutionCandyCostFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+
+                candyNamesFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
+
+                formsCountIndexFormatter.format(integerArrayFormat, -1).format(commentFormat, "Placeholder");
             }
         }
 
@@ -407,7 +433,6 @@ public class ApplicationDatabaseUpdater {
                 formsCountFormatter.format(integerArrayFormat, form.getForms().size());
                 formsCountFormatter.format(commentFormat, pokemonName);
 
-                formNamesFormatter.format(commentFormat, pokemonName);
                 formAttackFormatter.format(commentFormat, pokemonName);
                 formDefenseFormatter.format(commentFormat, pokemonName);
                 formStaminaFormatter.format(commentFormat, pokemonName);
@@ -427,6 +452,7 @@ public class ApplicationDatabaseUpdater {
                     formStaminaFormatter.format(integerArrayFormat, unnull(stats.getBaseStamina(), -1));
                     formStaminaFormatter.format(commentFormat, formName);
                 }
+                formNamesFormatter.format(commentFormat, pokemonName);
             }
         }
 


### PR DESCRIPTION
v5.5.5 Attempted to update game master for Galarian pokemon, but broke because of the fragile hardcoded patch for non-consecutive pokedex entries near the end of the list. This cause the app to consistently crash on startup 
v5.5.6 Removes the patch in favor of padding the resource files with placeholder values for pokemon not yet in the game. This fixed the crash issue, but may have negatively affected form detection on e.g. Perrserker